### PR TITLE
Indicate current page in single page/blog post side nav

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,4 +1,5 @@
 {{ partial "header" . }}
+{{ $currentURL := .URL }}
 
 <div class="tk-pageheader">
   <div class="container">
@@ -16,7 +17,7 @@
           <ul class="nav">
             {{ range .Site.Menus.blog }}
             <li class="active">
-              <a href="{{ .URL }}" class="text-muted">{{ .Name }}</a>
+              <a href="{{ .URL }}" {{ if not (eq $currentURL .URL) }}class="text-muted"{{ end }}>{{ .Name }}</a>
             </li>
             {{ end }}
           </ul>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,4 +1,5 @@
 {{ partial "header" . }}
+{{ $currentURL := .URL }}
 
 <div class="tk-pageheader">
   <div class="container">
@@ -20,7 +21,7 @@
             <ul class="nav">
               {{ range .Site.Menus.getting_started }}
               <li class="active">
-                <a href="{{ .URL }}" class="text-muted">{{ .Name }}</a>
+                <a href="{{ .URL }}" {{ if not (eq $currentURL .URL) }}class="text-muted"{{ end }}>{{ .Name }}</a>
               </li>
               {{ end }}
             </ul>
@@ -34,7 +35,7 @@
             <ul class="nav">
               {{ range .Site.Menus.going_deeper }}
               <li class="active">
-                <a href="{{ .URL }}" class="text-muted">{{ .Name }}</a>
+                <a href="{{ .URL }}" {{ if not (eq $currentURL .URL) }}class="text-muted"{{ end }}>{{ .Name }}</a>
               </li>
               {{ end }}
             </ul>


### PR DESCRIPTION
All links in the sidenav currently get the `text-muted` class. This threw me off a bit when I was browsing through documentation.