### PR TITLE
Add link for blog RSS feed so browsers can see it

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,6 +12,9 @@
     <link rel="stylesheet" href="/css/font-awesome.min.css">
     <link rel="stylesheet" href="/css/tokio.css">
 
+    <!-- Blog feed link -->
+    <link rel="alternate" type="application/rss+xml" href="https://tokio.rs/blog/index.xml" />
+
     <title>{{ .Title }}</title>
   </head>
   <body>


### PR DESCRIPTION
Fixes #10 . To see the change, open the website in Firefox and note that the "Subscribe to This Page..." option is enabled under the Bookmarks menu.

This puts the link on all pages by default. I don't see any harm in that, but if it should only be on the blog pages, that probably requires some conditional formatting in Hugo that I don't know how to do yet.