### PR TITLE
Fix typo in reactor docs

### DIFF
--- a/content/docs/getting-started/reactor.md
+++ b/content/docs/getting-started/reactor.md
@@ -160,7 +160,7 @@ another kind of handle to [`Core`]). [`Remote`], however, can be sent across
 threads. The [`Remote`] type also currently only has a
 [`spawn`][`Remote::spawn`] function. This [`spawn`][`Remote::spawn`] is
 importantly different from [`Handle::spawn`] in that it takes a *closure* which
-is `Send` (can be sent across threads) which crates a future. The created future
+is `Send` (can be sent across threads) which creates a future. The created future
 is then spawned onto the event loop to be executed locally.
 
 The closure provided, when run, is yielded a [`Handle`] as proof that it's


### PR DESCRIPTION
I think `crates` here is meant to be `creates`