### PR TITLE
unwraps -> expects

### DIFF
--- a/content/docs/getting-started/db.md
+++ b/content/docs/getting-started/db.md
@@ -70,13 +70,15 @@ Next up, let's get through the boilerplate of setting up our server:
 
 ```rust,ignore
 fn main() {
-    let addr = "127.0.0.1:8080".parse().unwrap();
+    let addr = "127.0.0.1:8080".parse().expect("Failed to parse address");
     let thread_pool = CpuPool::new(10);
 
     let db_url = "postgres://postgres@localhost";
     let db_config = r2d2::Config::default();
-    let db_manager = PostgresConnectionManager::new(db_url, TlsMode::None).unwrap();
-    let db_pool = r2d2::Pool::new(db_config, db_manager).unwrap();
+    let db_manager = PostgresConnectionManager::new(db_url, TlsMode::None)
+        .expect("Failed to create connection manager");
+    let db_pool = r2d2::Pool::new(db_config, db_manager)
+       .expect("Failed to create connection pool");
 
     TcpServer::new(tokio_minihttp::Http, addr).serve(move || {
         // ...
@@ -231,7 +233,8 @@ our implementation of `Service::call` let's take a look at the last piece:
 
 ```rust,ignore
 msg.map(|msg| {
-    let json = rustc_serialize::json::encode(&msg).unwrap();
+    let json = rustc_serialize::json::encode(&msg)
+        .expect("Cannot convert message to JSON");
     let mut response = Response::new();
     response.header("Content-Type", "application/json");
     response.body(&json);
@@ -314,7 +317,8 @@ impl Service for Server {
         });
 
         msg.map(|msg| {
-            let json = rustc_serialize::json::encode(&msg).unwrap();
+            let json = rustc_serialize::json::encode(&msg)
+                .expect("Cannot convert message to JSON");
             let mut response = Response::new();
             response.header("Content-Type", "application/json");
             response.body(&json);
@@ -324,13 +328,15 @@ impl Service for Server {
 }
 
 fn main() {
-    let addr = "127.0.0.1:8080".parse().unwrap();
+    let addr = "127.0.0.1:8080".parse().expect("Failed to parse address");
     let thread_pool = CpuPool::new(10);
 
     let db_url = "postgres://postgres@localhost";
     let db_config = r2d2::Config::default();
-    let db_manager = PostgresConnectionManager::new(db_url, TlsMode::None).unwrap();
-    let db_pool = r2d2::Pool::new(db_config, db_manager).unwrap();
+    let db_manager = PostgresConnectionManager::new(db_url, TlsMode::None)
+        .expect("Failed to create connection manager");
+    let db_pool = r2d2::Pool::new(db_config, db_manager)
+       .expect("Failed to create connection pool");;
 
     TcpServer::new(tokio_minihttp::Http, addr).serve(move || {
         Ok(Server {

--- a/content/docs/getting-started/pipeline-server.md
+++ b/content/docs/getting-started/pipeline-server.md
@@ -58,7 +58,7 @@ fn serve<S>(s: S) -> io::Result<()>
     let mut core = Core::new()?;
     let handle = core.handle();
 
-    let address = "0.0.0.0:12345".parse().unwrap();
+    let address = "0.0.0.0:12345".parse().expect("Failed to parse address");
     let listener = TcpListener::bind(&address, &handle)?;
 
     let connections = listener.incoming();

--- a/content/docs/getting-started/reactor.md
+++ b/content/docs/getting-started/reactor.md
@@ -71,9 +71,12 @@ use tokio_core::net::TcpListener;
 use tokio_core::reactor::Core;
 
 fn main() {
-    let mut core = Core::new().unwrap();
-    let listener = TcpListener::bind(&"127.0.0.1:8080".parse().unwrap(),
-                                     &core.handle()).unwrap();
+    let mut core = Core::new()
+        .expect("Encountered IO error when creating reactor core");
+    let addr = "127.0.0.1:8080".parse(i)
+                               .expect("Failed to parse address");
+    let listener = TcpListener::bind(&addr, &core.handle())
+            .expect("Failed to bind listener to local port");
 
     let server = listener.incoming().for_each(|(client, client_addr)| {
         // process `client` by spawning a new task ...
@@ -81,7 +84,7 @@ fn main() {
         Ok(()) // keep accepting connections
     });
 
-    core.run(server).unwrap();
+    core.run(server).expect("Running server failed");
 }
 ```
 
@@ -90,7 +93,7 @@ futures or otherwise one-off tasks. Some pseudo-code for this could look like:
 
 ```rust,ignore
 let my_request = http::get("https://www.rust-lang.org");
-let my_response = my_context.core.run(my_request).unwrap();
+let my_response = my_context.core.run(my_request).expect("Running server failed");
 ```
 
 The [`Core`] could be stashed in a local context which is used whenever

--- a/content/docs/getting-started/simple-server.md
+++ b/content/docs/getting-started/simple-server.md
@@ -388,7 +388,7 @@ use tokio_proto::TcpServer;
 
 fn main() {
     // Specify the localhost address
-    let addr = "0.0.0.0:12345".parse().unwrap();
+    let addr = "0.0.0.0:12345".parse().expect("Failed to parse address");
 
     // The builder requires a protocol and an address
     let server = TcpServer::new(LineProto, addr);

--- a/content/docs/getting-started/streams-and-sinks.md
+++ b/content/docs/getting-started/streams-and-sinks.md
@@ -81,9 +81,11 @@ use tokio_core::reactor::Core;
 use tokio_core::net::TcpListener;
 
 fn main() {
-    let mut core = Core::new().unwrap();
-    let address = "0.0.0.0:12345".parse().unwrap();
-    let listener = TcpListener::bind(&address, &core.handle()).unwrap();
+    let mut core = Core::new()
+        .expect("Encountered IO error when creating reactor core");
+    let address = "0.0.0.0:12345".parse().expect("Failed to parse address");
+    let listener = TcpListener::bind(&address, &core.handle())
+        .expect("Failed to bind listener to local port");
 
     let connections = listener.incoming();
     let welcomes = connections.and_then(|(socket, _peer_addr)| {
@@ -93,14 +95,15 @@ fn main() {
         Ok(())
     });
 
-    core.run(server).unwrap();
+    core.run(server).expect("Running server failed");
 }
 ```
 
 That was easy! Let's pick apart a few key lines. First, there's the *reactor setup*:
 
 ```rust,ignore
-let mut core = Core::new().unwrap();
+let mut core = Core::new()
+    .expect("Encountered IO error when creating reactor core");
 ```
 
 We'll cover reactors (aka *event loops*) in detail in the next section. For now,
@@ -111,7 +114,8 @@ here we're working at a lower level.
 We then set up an async TCP listener, associated with that reactor:
 
 ```rust,ignore
-let listener = TcpListener::bind(&address, &core.handle()).unwrap();
+let listener = TcpListener::bind(&address, &core.handle())
+    .expect("Failed to bind listener to local port");
 ```
 
 Our first encounter with streams is the `incoming` stream:
@@ -176,7 +180,7 @@ up the reactor. We do both in a single step, by using the server as the *primary
 future* of the reactor:
 
 ```rust,ignore
-core.run(server).unwrap();
+core.run(server).expect("Running server failed");
 ```
 
 The reactor's event loop will keep running on the current thread until the

--- a/content/docs/getting-started/tls.md
+++ b/content/docs/getting-started/tls.md
@@ -29,11 +29,18 @@ use tokio_core::reactor::Core;
 use tokio_tls::TlsConnectorExt;
 
 fn main() {
-    let mut core = Core::new().unwrap();
+    let mut core = Core::new()
+        .expect("Encountered IO error when creating reactor core");
     let handle = core.handle();
-    let addr = "www.rust-lang.org:443".to_socket_addrs().unwrap().next().unwrap();
+    let addr = "www.rust-lang.org:443".to_socket_addrs()
+                                      .expect("Parsing address failed")
+                                      .next()
+                                      .expect("Should have parsed single address");
 
-    let cx = TlsConnector::builder().unwrap().build().unwrap();
+    let cx = TlsConnector::builder()
+        .expect("Constructing TlsConnector failed")
+        .build()
+        .expect("Constructing TlsConnector failed");
     let socket = TcpStream::connect(&addr, &handle);
 
     let tls_handshake = socket.and_then(|socket| {
@@ -53,7 +60,8 @@ fn main() {
         tokio_core::io::read_to_end(socket, Vec::new())
     });
 
-    let (_socket, data) = core.run(response).unwrap();
+    let (_socket, data) = core.run(response)
+        .expect("Running server failed");
     println!("{}", String::from_utf8_lossy(&data));
 }
 ```
@@ -62,9 +70,13 @@ There's a lot to digest here, though, so let's walk through it
 line-by-line. First up in `main()`:
 
 ```rust,ignore
-let mut core = Core::new().unwrap();
+let mut core = Core::new()
+    .expect("Encountered IO error when creating reactor core");
 let handle = core.handle();
-let addr = "www.rust-lang.org:443".to_socket_addrs().unwrap().next().unwrap();
+let addr = "www.rust-lang.org:443".to_socket_addrs()
+                                  .expect("Parsing address failed")
+                                  .next()
+                                  .expect("Should have parsed single address");
 ```
 
 This is our standard version of creating an event loop and a handle to it. As
@@ -78,7 +90,10 @@ asynchronous DNS queries in the ecosystem.
 Next up we see:
 
 ```rust,ignore
-let cx = TlsConnector::builder().unwrap().build().unwrap();
+let cx = TlsConnector::builder()
+    .expect("Constructing TlsConnector failed")
+    .build()
+    .expect("Constructing TlsConnector failed");
 let socket = TcpStream::connect(&addr, &handle);
 ```
 
@@ -200,7 +215,8 @@ To actually execute our future and drive it to completion we'll need to run the
 event loop:
 
 ```rust,ignore
-let (_socket, data) = core.run(response).unwrap();
+let (_socket, data) = core.run(response)
+    .expect("Running server failed");
 println!("{}", String::from_utf8_lossy(&data));
 ```
 

--- a/content/docs/going-deeper/multiplex.md
+++ b/content/docs/going-deeper/multiplex.md
@@ -210,7 +210,7 @@ impl Service for Echo {
 
 fn main() {
     // Specify the localhost address
-    let addr = "0.0.0.0:12345".parse().unwrap();
+    let addr = "0.0.0.0:12345".parse().expect("Failed to parse address");
 
     // The builder requires a protocol and an address
     let server = TcpServer::new(LineProto, addr);

--- a/content/docs/going-deeper/streaming.md
+++ b/content/docs/going-deeper/streaming.md
@@ -383,7 +383,7 @@ impl Service for PrintStdout {
 
 fn main() {
     // Specify the localhost address
-    let addr = "0.0.0.0:12345".parse().unwrap();
+    let addr = "0.0.0.0:12345".parse().expect("Failed to parse address");
 
     // The builder requires a protocol and an address
     let server = TcpServer::new(LineProto, addr);

--- a/content/docs/going-deeper/synchronization.md
+++ b/content/docs/going-deeper/synchronization.md
@@ -44,7 +44,7 @@ fn main() {
     });
 
     let rx = rx.map(|x| x + 3);
-    let result = rx.wait().unwrap();
+    let result = rx.wait().expect("Computation failed");
     assert_eq!(result, 203);
 }
 ```
@@ -104,7 +104,7 @@ fn main() {
     });
 
     let future = future::poll_fn(|| tx.poll_cancel());
-    future.wait().unwrap();
+    future.wait().expect("Future failed to complete");
 }
 ```
 
@@ -161,7 +161,7 @@ fn stdin() -> BoxStream<String, io::Error> {
         }
     });
 
-    rx.then(|r| r.unwrap()).boxed()
+    rx.then(|r| r.expect("Future was canceled")).boxed()
 }
 #
 # fn main() {}

--- a/examples/pipeline-core/src/main.rs
+++ b/examples/pipeline-core/src/main.rs
@@ -44,7 +44,7 @@ fn serve<S>(s: S) -> io::Result<()>
     let mut core = Core::new()?;
     let handle = core.handle();
 
-    let address = "0.0.0.0:12345".parse().unwrap();
+    let address = "0.0.0.0:12345".parse().expect("Failed to parse address");
     let listener = TcpListener::bind(&address, &handle)?;
 
     let connections = listener.incoming();

--- a/examples/streams/src/main.rs
+++ b/examples/streams/src/main.rs
@@ -6,9 +6,11 @@ use tokio_core::reactor::Core;
 use tokio_core::net::TcpListener;
 
 fn main() {
-    let mut core = Core::new().unwrap();
-    let address = "0.0.0.0:12345".parse().unwrap();
-    let listener = TcpListener::bind(&address, &core.handle()).unwrap();
+    let mut core = Core::new()
+        .expect("Encountered IO error when creating reactor core");
+    let address = "0.0.0.0:12345".parse().expect("Failed to parse address");
+    let listener = TcpListener::bind(&address, &core.handle())
+        .expect("Failed to bind listener to local port");
 
     let handle = core.handle();
     let server = listener.incoming().for_each(|(socket, _peer_addr)| {
@@ -18,5 +20,5 @@ fn main() {
         Ok(())
     });
 
-    core.run(server).unwrap();
+    core.run(server).expect("Running server failed");
 }

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -54,12 +54,14 @@ use tokio_core::reactor::Core;
 
 fn main() {
     // Create the event loop that will drive this server
-    let mut core = Core::new().unwrap();
+    let mut core = Core::new()
+      .expect("Encountered IO error when creating reactor core");
     let handle = core.handle();
 
     // Bind the server's socket
-    let addr = "127.0.0.1:12345".parse().unwrap();
-    let sock = TcpListener::bind(&addr, &handle).unwrap();
+    let addr = "127.0.0.1:12345".parse().expect("Failed to parse address");
+    let sock = TcpListener::bind(&addr, &handle)
+      .expect("Failed to bind listener to local port");
 
     // Pull out a stream of sockets for incoming connections
     let server = sock.incoming().for_each(|(sock, _)| {
@@ -85,7 +87,7 @@ fn main() {
     });
 
     // Spin up the server on the event loop
-    core.run(server).unwrap();
+    core.run(server).expect("Running server failed");
 }
 </code>
         </pre>


### PR DESCRIPTION
We really should avoid using unwrap in example documentation, `.expect()` is better and more clearly conveys the "better error handling goes here if you need it" message.


r? @steveklabnik