### PR TITLE
Minor code cleanup in LineCodec example

### DIFF
--- a/content/docs/getting-started/simple-server.md
+++ b/content/docs/getting-started/simple-server.md
@@ -114,7 +114,7 @@ fn decode(&mut self, buf: &mut EasyBuf) -> io::Result<Option<Self::In>> {
         buf.drain_to(1);
 
         // Turn this data into a UTF string and return it in a Frame.
-        return match str::from_utf8(&line.as_ref()) {
+        match str::from_utf8(line.as_slice()) {
             Ok(s) => Ok(Some(s.to_string())),
             Err(_) => Err(io::Error::new(io::ErrorKind::Other,
                                          "invalid UTF-8")),


### PR DESCRIPTION
* Remove an unncessary `return` keyword
* Remove an unnecessary `&` wrapper
* Use `EasyBuf::as_slice` everywhere (instead of `as_slice` once and `as_ref` once)