### PR TITLE
Use `extend` instead of `extend_from_slice`

### DIFF
--- a/content/docs/getting-started/simple-server.md
+++ b/content/docs/getting-started/simple-server.md
@@ -172,7 +172,7 @@ we won't provide support for error responses:
 fn encode(&mut self, msg: String, buf: &mut Vec<u8>)
          -> io::Result<()>
 {
-    buf.extend_from_slice(msg.as_bytes());
+    buf.extend(msg.as_bytes());
     buf.push(b'\n');
     Ok(())
 }

--- a/content/docs/going-deeper/multiplex.md
+++ b/content/docs/going-deeper/multiplex.md
@@ -146,8 +146,8 @@ impl Codec for LineCodec {
         let mut encoded_id = [0; 4];
         BigEndian::write_u32(&mut encoded_id, id as u32);
 
-        buf.extend_from_slice(&encoded_id);
-        buf.extend_from_slice(msg.as_bytes());
+        buf.extend(&encoded_id);
+        buf.extend(msg.as_bytes());
         buf.push(b'\n');
 
         Ok(())

--- a/content/docs/going-deeper/streaming.md
+++ b/content/docs/going-deeper/streaming.md
@@ -184,11 +184,11 @@ impl Codec for LineCodec {
                 // includes a streaming body is an empty string.
                 assert!(message.is_empty() == body);
 
-                buf.extend_from_slice(message.as_bytes());
+                buf.extend(message.as_bytes());
             }
             Frame::Body { chunk } => {
                 if let Some(chunk) = chunk {
-                    buf.extend_from_slice(chunk.as_bytes());
+                    buf.extend(chunk.as_bytes());
                 }
             }
             Frame::Error { error } => {


### PR DESCRIPTION
These are identical since rust-lang/rust#37094 landed, and
`extend_from_slice` will be deprecated in the future.