### PR TITLE
variable does not need to be mutable.

### DIFF
--- a/content/docs/getting-started/pipeline-server.md
+++ b/content/docs/getting-started/pipeline-server.md
@@ -64,7 +64,7 @@ fn serve<S>(s: S) -> io::Result<()>
     let connections = listener.incoming();
     let server = connections.for_each(move |(socket, _peer_addr)| {
         let (writer, reader) = socket.framed(LineCodec).split();
-        let mut service = s.new_service()?;
+        let service = s.new_service()?;
 
         let responses = reader.and_then(move |req| service.call(req));
         let server = writer.send_all(responses)


### PR DESCRIPTION
During compilation a friendly warning informed me that the `service` variable does not need to be mutable.

```
warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
  --> src/main.rs:58:13
   |
58 |         let mut service = s.new_service()?;
   |             ^^^^^^^^^^^
```