### PR TITLE
fix typo in Multiplexed protocols

### DIFF
--- a/content/docs/going-deeper/multiplex.md
+++ b/content/docs/going-deeper/multiplex.md
@@ -203,7 +203,7 @@ impl Service for Echo {
     type Error = io::Error;
     type Future = BoxFuture<Self::Response, Self::Error>;
 
-    fn call(&mut self, req: Self::Request) -> Self::Future {
+    fn call(&self, req: Self::Request) -> Self::Future {
         future::ok(req).boxed()
     }
 }


### PR DESCRIPTION
In Multiplexed protocols page, differ from source code in example.

Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>