### PR TITLE
add tokio-retry to third-party crates

### DIFF
--- a/content/docs/going-deeper/third-party.md
+++ b/content/docs/going-deeper/third-party.md
@@ -26,6 +26,7 @@ of Tokio itself, however, filling in more functionality!
   ability to work with futures as well
 * [`tk-sendfile`] allows using the `sendfile` syscall with Tokio
 * [`tokio-postgres`] is an asynchronous PostgreSQL driver
+* [`tokio-retry`] provides extensible asynchronous retry behaviours
 
 If you've got your own crate or know of others that should be present on this
 list, please feel free to send a PR!
@@ -49,3 +50,4 @@ list, please feel free to send a PR!
 [`tk-sendfile`]: https://crates.io/crates/tk-sendfile
 [`tokio-postgres`]: https://crates.io/crates/tokio-postgres
 [`thrussh`]: https://crates.io/crates/thrussh
+[`tokio-retry`]: https://github.com/srijs/rust-tokio-retry


### PR DESCRIPTION
I just released the second version of this crate, which is still in an earlier stage of development. Please let me know if there's a level of maturity you require of the crates listed here, and I can re-file the PR at a later stage when the crate has achieved greater stability.