### PR TITLE
Add a note on the async couchbase driver

### DIFF
--- a/content/docs/going-deeper/third-party.md
+++ b/content/docs/going-deeper/third-party.md
@@ -26,6 +26,7 @@ of Tokio itself, however, filling in more functionality!
   ability to work with futures as well
 * [`tk-sendfile`] allows using the `sendfile` syscall with Tokio
 * [`tokio-postgres`] is an asynchronous PostgreSQL driver
+* [`couchbase`] is an asynchronous driver for Couchbase, exposing Futures and Streams as first class response types.
 
 If you've got your own crate or know of others that should be present on this
 list, please feel free to send a PR!
@@ -49,3 +50,4 @@ list, please feel free to send a PR!
 [`tk-sendfile`]: https://crates.io/crates/tk-sendfile
 [`tokio-postgres`]: https://crates.io/crates/tokio-postgres
 [`thrussh`]: https://crates.io/crates/thrussh
+[`couchbase`]: https://crates.io/crates/couchbase


### PR DESCRIPTION
The couchbase SDK is future-driven from the ground up and fits very well into the tokio ecosystem. Here is an example: https://github.com/daschl/tokio-cb/blob/master/src/main.rs