### PR TITLE
Split "Going Deeper" section to make it easier to study

### DIFF
--- a/content/docs/getting-started/core.md
+++ b/content/docs/getting-started/core.md
@@ -2,7 +2,7 @@
 title = "High-level I/O using core"
 description = "Future, stream and sink-based APIs from tokio-io and tokio-core"
 menu = "getting_started"
-weight = 6
+weight = 106
 +++
 
 At this point, we've got a pretty solid grasp of what event loops are and how

--- a/content/docs/getting-started/db.md
+++ b/content/docs/getting-started/db.md
@@ -2,7 +2,7 @@
 title = "Example: serving database content using proto"
 description = "Writing a `fortune` server using proto"
 menu = "getting_started"
-weight = 3
+weight = 103
 +++
 
 In our previous example, an echo server, we didn't leverage the fact that a

--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -2,7 +2,7 @@
 title = "Futures"
 description = "A productive, zero-cost approach to asynchrony"
 menu = "getting_started"
-weight = 2
+weight = 102
 +++
 
 Tokio is fundamentally based on *asynchronous I/O*. While you don't need to have

--- a/content/docs/getting-started/pipeline-server.md
+++ b/content/docs/getting-started/pipeline-server.md
@@ -1,7 +1,7 @@
 +++
 title = "Example: a simple pipelined server using core"
 menu = "getting_started"
-weight = 7
+weight = 107
 +++
 
 Now that we've seen the basics of [high-level I/O using `tokio-core`](../core),

--- a/content/docs/getting-started/reactor.md
+++ b/content/docs/getting-started/reactor.md
@@ -2,7 +2,7 @@
 title = "Understanding event loops"
 description = "The heart of asynchronous processing"
 menu = "getting_started"
-weight = 5
+weight = 105
 +++
 
 Now we'll take a bit more of a dive into `tokio-core`. Keep in mind that this

--- a/content/docs/getting-started/simple-server.md
+++ b/content/docs/getting-started/simple-server.md
@@ -2,7 +2,7 @@
 title = "Example: an echo server using proto"
 description = ""
 menu = "getting_started"
-weight = 1
+weight = 101
 +++
 
 To kick off our tour of Tokio, we'll build a simple line-based echo server using

--- a/content/docs/getting-started/streams-and-sinks.md
+++ b/content/docs/getting-started/streams-and-sinks.md
@@ -2,7 +2,7 @@
 title = "Streams and sinks"
 description = "High-level async programming"
 menu = "getting_started"
-weight = 4
+weight = 104
 +++
 
 We've now seen a few examples of futures, which represent a *one-time*

--- a/content/docs/getting-started/tls.md
+++ b/content/docs/getting-started/tls.md
@@ -1,7 +1,7 @@
 +++
 title = "Example: a toy HTTP+TLS client using core"
 menu = "getting_started"
-weight = 8
+weight = 108
 +++
 
 Much of the functionality throughout the Tokio stack is generic, so as to be as

--- a/content/docs/getting-started/tokio.md
+++ b/content/docs/getting-started/tokio.md
@@ -1,7 +1,7 @@
 +++
 title = "What is Tokio?"
 menu = "getting_started"
-weight = 0
+weight = 100
 +++
 
 ##### Tokio is a platform for writing fast networking code in Rust.

--- a/content/docs/going-deeper-futures/futures-mechanics.md
+++ b/content/docs/going-deeper-futures/futures-mechanics.md
@@ -1,8 +1,8 @@
 +++
 title = "Essential combinators"
 description = "Common APIs for futures and stream programming"
-menu = "going_deeper"
-weight = 100
+menu = "going_deeper_futures"
+weight = 200
 +++
 
 We saw a few of the most important combinators in the

--- a/content/docs/going-deeper-futures/futures-mechanics.md
+++ b/content/docs/going-deeper-futures/futures-mechanics.md
@@ -3,6 +3,9 @@ title = "Essential combinators"
 description = "Common APIs for futures and stream programming"
 menu = "going_deeper_futures"
 weight = 200
+aliases = [
+  "/docs/going-deeper/futures-mechanics/"
+]
 +++
 
 We saw a few of the most important combinators in the

--- a/content/docs/going-deeper-futures/futures-model.md
+++ b/content/docs/going-deeper-futures/futures-model.md
@@ -1,8 +1,8 @@
 +++
 title = "The futures model in depth"
 description = "Understanding how futures, streams and sinks work"
-menu = "going_deeper"
-weight = 105
+menu = "going_deeper_futures"
+weight = 205
 +++
 
 At this point, we're ready to dig into the implementation details for futures,

--- a/content/docs/going-deeper-futures/futures-model.md
+++ b/content/docs/going-deeper-futures/futures-model.md
@@ -3,6 +3,9 @@ title = "The futures model in depth"
 description = "Understanding how futures, streams and sinks work"
 menu = "going_deeper_futures"
 weight = 205
+aliases = [
+  "/docs/going-deeper/futures-model/"
+]
 +++
 
 At this point, we're ready to dig into the implementation details for futures,

--- a/content/docs/going-deeper-futures/returning.md
+++ b/content/docs/going-deeper-futures/returning.md
@@ -3,6 +3,9 @@ title = "Returning futures"
 description = ""
 menu = "going_deeper_futures"
 weight = 201
+aliases = [
+  "/docs/going-deeper/returning/"
+]
 +++
 
 [`Future`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html

--- a/content/docs/going-deeper-futures/returning.md
+++ b/content/docs/going-deeper-futures/returning.md
@@ -1,8 +1,8 @@
 +++
 title = "Returning futures"
 description = ""
-menu = "going_deeper"
-weight = 101
+menu = "going_deeper_futures"
+weight = 201
 +++
 
 [`Future`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html

--- a/content/docs/going-deeper-futures/synchronization.md
+++ b/content/docs/going-deeper-futures/synchronization.md
@@ -3,6 +3,9 @@ title = "Synchronization"
 description = "Coordinating concurrent futures"
 menu = "going_deeper_futures"
 weight = 204
+aliases = [
+  "/docs/going-deeper/synchronization/"
+]
 +++
 
 The `futures` crate comes equipped with a small *futures-aware

--- a/content/docs/going-deeper-futures/synchronization.md
+++ b/content/docs/going-deeper-futures/synchronization.md
@@ -1,8 +1,8 @@
 +++
 title = "Synchronization"
 description = "Coordinating concurrent futures"
-menu = "going_deeper"
-weight = 104
+menu = "going_deeper_futures"
+weight = 204
 +++
 
 The `futures` crate comes equipped with a small *futures-aware

--- a/content/docs/going-deeper-futures/tasks.md
+++ b/content/docs/going-deeper-futures/tasks.md
@@ -1,8 +1,8 @@
 +++
 title = "Tasks and executors"
 description = "The guts of the task system"
-menu = "going_deeper"
-weight = 108
+menu = "going_deeper_futures"
+weight = 208
 +++
 
 The concepts of a tasks for futures were introduced in [the futures model in

--- a/content/docs/going-deeper-futures/tasks.md
+++ b/content/docs/going-deeper-futures/tasks.md
@@ -3,6 +3,9 @@ title = "Tasks and executors"
 description = "The guts of the task system"
 menu = "going_deeper_futures"
 weight = 208
+aliases = [
+  "/docs/going-deeper/tasks/"
+]
 +++
 
 The concepts of a tasks for futures were introduced in [the futures model in

--- a/content/docs/going-deeper-tokio/architecture.md
+++ b/content/docs/going-deeper-tokio/architecture.md
@@ -3,6 +3,9 @@ title = "Architecture overview"
 description = "An overview of Tokio's components and how they fit together"
 menu = "going_deeper_tokio"
 weight = 301
+aliases = [
+  "/docs/going-deeper/architecture/"
+]
 +++
 
 Most networking applications are structured in a layered fashion.

--- a/content/docs/going-deeper-tokio/architecture.md
+++ b/content/docs/going-deeper-tokio/architecture.md
@@ -1,8 +1,8 @@
 +++
 title = "Architecture overview"
 description = "An overview of Tokio's components and how they fit together"
-menu = "going_deeper"
-weight = 90
+menu = "going_deeper_tokio"
+weight = 301
 +++
 
 Most networking applications are structured in a layered fashion.

--- a/content/docs/going-deeper-tokio/core-low-level.md
+++ b/content/docs/going-deeper-tokio/core-low-level.md
@@ -1,8 +1,8 @@
 +++
 title = "Low-level I/O using core"
 description = ""
-menu = "going_deeper"
-weight = 106
+menu = "going_deeper_tokio"
+weight = 306
 +++
 
 We've seen some examples of [high level I/O]({{< relref "core.md" >}}) with

--- a/content/docs/going-deeper-tokio/core-low-level.md
+++ b/content/docs/going-deeper-tokio/core-low-level.md
@@ -3,6 +3,9 @@ title = "Low-level I/O using core"
 description = ""
 menu = "going_deeper_tokio"
 weight = 306
+aliases = [
+  "/docs/going-deeper/core-low-level/"
+]
 +++
 
 We've seen some examples of [high level I/O]({{< relref "core.md" >}}) with

--- a/content/docs/going-deeper-tokio/examples.md
+++ b/content/docs/going-deeper-tokio/examples.md
@@ -3,6 +3,9 @@ title = "Larger examples"
 description = ""
 menu = "going_deeper_tokio"
 weight = 309
+aliases = [
+  "/docs/going-deeper/examples/"
+]
 +++
 
 Often times when learning a new framework or if you're just getting your feet

--- a/content/docs/going-deeper-tokio/examples.md
+++ b/content/docs/going-deeper-tokio/examples.md
@@ -1,8 +1,8 @@
 +++
 title = "Larger examples"
 description = ""
-menu = "going_deeper"
-weight = 109
+menu = "going_deeper_tokio"
+weight = 309
 +++
 
 Often times when learning a new framework or if you're just getting your feet

--- a/content/docs/going-deeper-tokio/handshake.md
+++ b/content/docs/going-deeper-tokio/handshake.md
@@ -1,8 +1,8 @@
 +++
 title = "Connection handshakes"
 description = "How to handle initial steps in a protocol"
-menu = "going_deeper"
-weight = 104
+menu = "going_deeper_tokio"
+weight = 304
 +++
 
 Some protocols require some setup before they can start accepting requests. For

--- a/content/docs/going-deeper-tokio/handshake.md
+++ b/content/docs/going-deeper-tokio/handshake.md
@@ -3,6 +3,9 @@ title = "Connection handshakes"
 description = "How to handle initial steps in a protocol"
 menu = "going_deeper_tokio"
 weight = 304
+aliases = [
+  "/docs/going-deeper/handshake/"
+]
 +++
 
 Some protocols require some setup before they can start accepting requests. For

--- a/content/docs/going-deeper-tokio/multiplex.md
+++ b/content/docs/going-deeper-tokio/multiplex.md
@@ -1,8 +1,8 @@
 +++
 title = "Multiplexed protocols"
 description = "An introduction to implementing a server for a multiplexed protocol"
-menu = "going_deeper"
-weight = 102
+menu = "going_deeper_tokio"
+weight = 302
 +++
 
 A *multiplexed* socket connection is one that allows many concurrent requests to

--- a/content/docs/going-deeper-tokio/multiplex.md
+++ b/content/docs/going-deeper-tokio/multiplex.md
@@ -3,6 +3,9 @@ title = "Multiplexed protocols"
 description = "An introduction to implementing a server for a multiplexed protocol"
 menu = "going_deeper_tokio"
 weight = 302
+aliases = [
+  "/docs/going-deeper/multiplex/"
+]
 +++
 
 A *multiplexed* socket connection is one that allows many concurrent requests to

--- a/content/docs/going-deeper-tokio/streaming.md
+++ b/content/docs/going-deeper-tokio/streaming.md
@@ -1,8 +1,8 @@
 +++
 title = "Streaming protocols"
 description = "An introduction to implementing a server for a streaming protocol"
-menu = "going_deeper"
-weight = 103
+menu = "going_deeper_tokio"
+weight = 303
 +++
 
 All of the previous guides used protocols that where requests and responses were

--- a/content/docs/going-deeper-tokio/streaming.md
+++ b/content/docs/going-deeper-tokio/streaming.md
@@ -3,6 +3,9 @@ title = "Streaming protocols"
 description = "An introduction to implementing a server for a streaming protocol"
 menu = "going_deeper_tokio"
 weight = 303
+aliases = [
+  "/docs/going-deeper/streaming/"
+]
 +++
 
 All of the previous guides used protocols that where requests and responses were

--- a/content/docs/going-deeper-tokio/third-party.md
+++ b/content/docs/going-deeper-tokio/third-party.md
@@ -3,6 +3,9 @@ title = "Third-party crates"
 description = ""
 menu = "going_deeper_tokio"
 weight = 310
+aliases = [
+  "/docs/going-deeper/third-party/"
+]
 +++
 
 Currently the [`futures`], [`tokio-core`], [`tokio-service`], and [`tokio-proto`] crates provide

--- a/content/docs/going-deeper-tokio/third-party.md
+++ b/content/docs/going-deeper-tokio/third-party.md
@@ -1,8 +1,8 @@
 +++
 title = "Third-party crates"
 description = ""
-menu = "going_deeper"
-weight = 110
+menu = "going_deeper_tokio"
+weight = 310
 +++
 
 Currently the [`futures`], [`tokio-core`], [`tokio-service`], and [`tokio-proto`] crates provide

--- a/content/docs/going-deeper-tokio/transports.md
+++ b/content/docs/going-deeper-tokio/transports.md
@@ -3,6 +3,9 @@ title = "Working with transports"
 description = "How to implement, use, and augment transports in Tokio"
 menu = "going_deeper_tokio"
 weight = 307
+aliases = [
+  "/docs/going-deeper/transports/"
+]
 +++
 
 A transport in Tokio is a full duplex channel of frame values. The transport is

--- a/content/docs/going-deeper-tokio/transports.md
+++ b/content/docs/going-deeper-tokio/transports.md
@@ -1,8 +1,8 @@
 +++
 title = "Working with transports"
 description = "How to implement, use, and augment transports in Tokio"
-menu = "going_deeper"
-weight = 107
+menu = "going_deeper_tokio"
+weight = 307
 +++
 
 A transport in Tokio is a full duplex channel of frame values. The transport is

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -28,12 +28,26 @@
           </div>
 
           <br/>
-          <h5>Going deeper</h5>
+          <h5>Going deeper: Futures</h5>
           <hr/>
 
           <div class="" id="">
             <ul class="nav">
-              {{ range .Site.Menus.going_deeper }}
+              {{ range .Site.Menus.going_deeper_futures }}
+              <li class="active">
+                <a href="{{ .URL }}" {{ if not (eq $currentURL .URL) }}class="text-muted"{{ end }}>{{ .Name }}</a>
+              </li>
+              {{ end }}
+            </ul>
+          </div>
+
+          <br/>
+          <h5>Going deeper: Tokio</h5>
+          <hr/>
+
+          <div class="" id="">
+            <ul class="nav">
+              {{ range .Site.Menus.going_deeper_tokio }}
               <li class="active">
                 <a href="{{ .URL }}" {{ if not (eq $currentURL .URL) }}class="text-muted"{{ end }}>{{ .Name }}</a>
               </li>


### PR DESCRIPTION
# What?

Reorganises the "Going Deeper" section into two:

* "Going Deeper: Futures"
* "Going Deeper: Tokio"

# Why?

When I found the docs on tokio.rs I was really happy. It was genuinely fun working through the Getting Started section. But I'm finding it hard getting beyond this. One of the problems I noticed is the way the Futures and Tokio content is interleaved has made it a little difficult to absorb and build strong conceptual models.

Tokio is really fascinating but it's a bit ahead of where I am right now. What I want to do is learn the basic facilities for working with async code in Rust first. I've experimented with threads and channels, now I want to study Futures.

So I'm suggesting we separate the two topics. I'm also wondering whether to split the Tokio section into "Going Deeper: tokio-proto" and ""Going Deeper: tokio-core", which would continue the model introduced in "What is Tokio?".

# What does it look like?

![screencapture-localhost-1313-docs-going-deeper-futures-futures-mechanics-1492719361214](https://cloud.githubusercontent.com/assets/306583/25251918/fc39a008-2612-11e7-8d21-3a20bfbf0a5c.png)
