### PR TITLE
Remove the extra `BufMut` import.

### DIFF
--- a/content/docs/getting-started/simple-server.md
+++ b/content/docs/getting-started/simple-server.md
@@ -66,7 +66,7 @@ this, we'll need a couple of tools from `tokio-io`:
 # extern crate tokio_io;
 use std::io;
 use std::str;
-use bytes::{BytesMut, BufMut};
+use bytes::BytesMut;
 use tokio_io::codec::{Encoder, Decoder};
 # fn main() {}
 ```
@@ -175,7 +175,7 @@ we won't provide support for error responses:
 #
 # use std::io;
 # use std::str;
-# use bytes::{BytesMut, BufMut};
+# use bytes::BytesMut;
 # use tokio_io::codec::{Encoder, Decoder};
 #
 # struct LineCodec;


### PR DESCRIPTION
In the simple server example `BufMut` is imported from the bytes crate, but isn't used (`BytesMut` is the only trait needed). Removing the import might improve clarity, but there may have been another reason for the import that I am not aware of.

Thanks. 😄 