### PR TITLE
Clarify the comments above the type aliases in the `ServerProto` impl block

### DIFF
--- a/content/docs/getting-started/simple-server.md
+++ b/content/docs/getting-started/simple-server.md
@@ -256,10 +256,10 @@ use tokio_io::codec::Framed;
 # struct LineProto;
 
 impl<T: AsyncRead + AsyncWrite + 'static> ServerProto<T> for LineProto {
-    /// For this protocol style, `Request` matches the codec `In` type
+    /// For this protocol style, `Request` matches the `Item` type of the codec's `Encoder`
     type Request = String;
 
-    /// For this protocol style, `Response` matches the coded `Out` type
+    /// For this protocol style, `Response` matches the `Item` type of the codec's `Decoder`
     type Response = String;
 
     /// A bit of boilerplate to hook in the codec:


### PR DESCRIPTION
In the simple server example there are two comments that where not clear to me. This PR updates the comments to be more in line with my understanding (which may or may not be correct). If this is not quite right I would be happy to update it, or just have this closed.

Thanks 😄 