### PR TITLE
Populate database in getting started db example.

### DIFF
--- a/content/docs/getting-started/db.md
+++ b/content/docs/getting-started/db.md
@@ -177,7 +177,8 @@ flexibly define the future internally.
 [`BoxFuture`]: https://docs.rs/futures/0.1/futures/future/type.BoxFuture.html
 
 
-Well also need a `Message` struct that we can use to serialize the row that we will be getting from the database into json using `serde`:
+Well also need a `Message` struct that we can use to serialize the row that we
+will be getting from the database into json using `serde`:
 
 ```rust,ignore
 #[derive(Serialize)]
@@ -186,6 +187,7 @@ struct Message {
     body: String,
 }
 ```
+
 
 Next up, let's start implementing `call`. First we can verify that the HTTP
 request is indeed `/db`:
@@ -267,7 +269,9 @@ we can return it.
 [`boxed`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html#method.boxed
 
 
-Finally before we run the example, we need to set up the database to have a `greetings` table that we can query from. Run the following queries in psql to create and populate the table:
+Finally before we run the example, we need to set up the database to have a
+`greetings` table that we can query from. Run the following queries within the
+`psql` command to create and populate the table:
 
 ```sql,ignore
 CREATE TABLE greetings (

--- a/content/docs/getting-started/db.md
+++ b/content/docs/getting-started/db.md
@@ -255,6 +255,24 @@ we can return it.
 [`CpuFuture`]: https://docs.rs/futures-cpupool/0.1/futures_cpupool/struct.CpuFuture.html
 [`boxed`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html#method.boxed
 
+
+Finally before we run the example, we need to set up the database to have a `greetings` table that we can query from. Run the following queries in psql to create and populate the table:
+
+```sql,ignore
+CREATE TABLE greetings (
+    id serial,
+    body text
+);
+
+INSERT INTO greetings (body) VALUES
+    ('Hello'),
+    ('안녕하세요'),
+    ('Bonjour'),
+    ('好'),
+    ('Здравствуйте');
+```
+
+
 ### [Complete example](#complete) {#complete}
 
 ```rust,no_run

--- a/content/docs/getting-started/db.md
+++ b/content/docs/getting-started/db.md
@@ -214,13 +214,13 @@ Once we've got a database connection, we can now use [`postgres`] to load a row
 with the `random_id` we generated earlier:
 
 ```rust,ignore
-let stmt = conn.prepare_cached("SELECT * FROM World WHERE id = $1")?;
+let stmt = conn.prepare_cached("SELECT * FROM greeting WHERE id = $1")?;
 let rows = stmt.query(&[&random_id])?;
 let row = rows.get(0);
 
 Ok(Message {
     id: row.get("id"),
-    randomNumber: row.get("randomNumber"),
+    body: row.get("body"),
 })
 ```
 
@@ -311,7 +311,7 @@ struct Server {
 #[derive(Serialize)]
 struct Message {
     id: i32,
-    randomNumber: i32,
+    body: i32,
 }
 
 impl Service for Server {
@@ -330,13 +330,13 @@ impl Service for Server {
                 io::Error::new(io::ErrorKind::Other, format!("timeout: {}", e))
             })?;
 
-            let stmt = conn.prepare_cached("SELECT * FROM World WHERE id = $1")?;
+            let stmt = conn.prepare_cached("SELECT * FROM greetings WHERE id = $1")?;
             let rows = stmt.query(&[&random_id])?;
             let row = rows.get(0);
 
             Ok(Message {
                 id: row.get("id"),
-                randomNumber: row.get("randomNumber"),
+                body: row.get("body"),
             })
         });
 

--- a/content/docs/getting-started/db.md
+++ b/content/docs/getting-started/db.md
@@ -188,7 +188,7 @@ just panic if you request a different path. Next up let's generate the id of
 the row that we're going to look up:
 
 ```rust,ignore
-let random_id = rand::thread_rng().gen_range(0, 5);
+let random_id = rand::thread_rng().gen_range(1, 5);
 ```
 
 And now with this in hand comes the real meat. Let's start executing our
@@ -323,7 +323,7 @@ impl Service for Server {
     fn call(&self, req: Request) -> Self::Future {
         assert_eq!(req.path(), "/db");
 
-        let random_id = rand::thread_rng().gen_range(0, 5);
+        let random_id = rand::thread_rng().gen_range(1, 5);
         let db = self.db_pool.clone();
         let msg = self.thread_pool.spawn_fn(move || {
             let conn = db.get().map_err(|e| {

--- a/content/docs/getting-started/db.md
+++ b/content/docs/getting-started/db.md
@@ -188,7 +188,7 @@ just panic if you request a different path. Next up let's generate the id of
 the row that we're going to look up:
 
 ```rust,ignore
-let random_id = rand::thread_rng().gen_range(0, 10_000);
+let random_id = rand::thread_rng().gen_range(0, 5);
 ```
 
 And now with this in hand comes the real meat. Let's start executing our
@@ -311,7 +311,7 @@ struct Server {
 #[derive(Serialize)]
 struct Message {
     id: i32,
-    body: i32,
+    body: String,
 }
 
 impl Service for Server {
@@ -323,7 +323,7 @@ impl Service for Server {
     fn call(&self, req: Request) -> Self::Future {
         assert_eq!(req.path(), "/db");
 
-        let random_id = rand::thread_rng().gen_range(0, 10_000);
+        let random_id = rand::thread_rng().gen_range(0, 5);
         let db = self.db_pool.clone();
         let msg = self.thread_pool.spawn_fn(move || {
             let conn = db.get().map_err(|e| {

--- a/content/docs/getting-started/db.md
+++ b/content/docs/getting-started/db.md
@@ -176,6 +176,17 @@ flexibly define the future internally.
 
 [`BoxFuture`]: https://docs.rs/futures/0.1/futures/future/type.BoxFuture.html
 
+
+Well also need a `Message` struct that we can use to serialize the row that we will be getting from the database into json using `serde`:
+
+```rust,ignore
+#[derive(Serialize)]
+struct Message {
+    id: i32,
+    body: String,
+}
+```
+
 Next up, let's start implementing `call`. First we can verify that the HTTP
 request is indeed `/db`:
 
@@ -303,15 +314,15 @@ use tokio_minihttp::{Request, Response};
 use tokio_proto::TcpServer;
 use tokio_service::Service;
 
-struct Server {
-    thread_pool: CpuPool,
-    db_pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager>,
-}
-
 #[derive(Serialize)]
 struct Message {
     id: i32,
     body: String,
+}
+
+struct Server {
+    thread_pool: CpuPool,
+    db_pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager>,
 }
 
 impl Service for Server {


### PR DESCRIPTION
This PR attempts to improve on the database example in the getting started section by:

1. Adding a section of creating the table that the example will query from
1. Switching from using a `randomNumber` column in a `World` table to a `body` column from a `greetings` table.

The example will now return a random greeting from the table and return a response such as:

```json
{"id":3,"body":"Bonjour"}
```