### PR TITLE
Added tokio-core dependency

### DIFF
--- a/content/docs/getting-started/simple-server.md
+++ b/content/docs/getting-started/simple-server.md
@@ -20,6 +20,7 @@ We'll need to add dependencies on the Tokio stack:
 bytes = "0.4"
 futures = "0.1"
 tokio-io = "0.1"
+tokio-core = "0.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
 ```


### PR DESCRIPTION
While reading the docs and examples i came with an error:
```
  |
3 | extern crate tokio_core;
  | ^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate
```

Then i noticed that `tokio-core` wasn't referenced on the doc's dependencies.