### PR TITLE
Respond to shellcheck lints on ci/test.sh

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -ex
 
 if [ ! -d tmp ]; then
@@ -24,8 +25,8 @@ EOF
   cargo build --manifest-path tmp/Cargo.toml
 fi
 
-rand=`ls tmp/target/debug/deps/librand-*.rlib`
-for f in `git ls-files | grep 'md$'`; do
-  echo $f
-  rustdoc --test $f -L tmp/target/debug/deps --extern rand=$rand
+rand=$(ls tmp/target/debug/deps/librand-*.rlib)
+for f in $(git ls-files | grep 'md$'); do
+  echo "$f"
+  rustdoc --test "$f" -L tmp/target/debug/deps --extern "rand=$rand"
 done


### PR DESCRIPTION
Noticed right off the bat that I couldn't `./` this script. Applied
generally accepted shellchecked lints and recommendations to this
script.