### PR TITLE
Add Edit on GitHub Link to documentation pages.

### DIFF
--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -84,6 +84,9 @@
     </div>
     <div class="col-md-9">
       <div class="tk-content">
+        <div class="github-edit">
+            <a class="fa fa-github" href="https://github.com/tokio-rs/website/tree/master/content/{{ .File.Path }}"> Edit on GitHub</a>
+        </div>
         {{ .Content }}
         <!-- Yes, we have to use *Prev* to get the next content, because the
         weights are sorted inversely to how they are actually displayed... -->

--- a/static/css/tokio.css
+++ b/static/css/tokio.css
@@ -66,6 +66,25 @@ img {
   text-align: right;
 }
 
+.github-edit .fa {
+  font-family: inherit;
+}
+
+.github-edit .fa:before {
+  font-family: "FontAwesome";
+  display: inline-block;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  text-decoration: inherit;
+}
+
+.github-edit {
+  text-align: right;
+  padding-bottom: 1rem;
+}
+
+
 /*
  *
  * ===== Navbar =====


### PR DESCRIPTION
Hopefully this might encourage more contribution.

This is modeled after https://readthedocs.org/ and many other
documentation sites out there that have a GitHub repo backing them with
a generated link to the backing document.

- - -

Examples from elsewhere:
![ionicframework com-docs-intro-installation- laptop with mdpi screen](https://user-images.githubusercontent.com/5363/29810598-47f85c02-8c55-11e7-848f-ad30114f0bf2.png)

<img width="1113" alt="screen shot 2017-08-29 at 12 37 57 am" src="https://user-images.githubusercontent.com/5363/29810552-1a363c76-8c55-11e7-8549-d6cb38d24197.png">

---

This PR:

![localhost-1313-docs-getting-started-futures-](https://user-images.githubusercontent.com/5363/29810651-7f7e4402-8c55-11e7-9fc1-0519b002e6e7.png)

