### PR TITLE
[Minor] Replace doc comments with regular ones

### DIFF
--- a/content/docs/getting-started/simple-server.md
+++ b/content/docs/getting-started/simple-server.md
@@ -282,13 +282,13 @@ use tokio_io::codec::Framed;
 # struct LineProto;
 
 impl<T: AsyncRead + AsyncWrite + 'static> ServerProto<T> for LineProto {
-    /// For this protocol style, `Request` matches the `Item` type of the codec's `Decoder`
+    // For this protocol style, `Request` matches the `Item` type of the codec's `Decoder`
     type Request = String;
 
-    /// For this protocol style, `Response` matches the `Item` type of the codec's `Encoder`
+    // For this protocol style, `Response` matches the `Item` type of the codec's `Encoder`
     type Response = String;
 
-    /// A bit of boilerplate to hook in the codec:
+    // A bit of boilerplate to hook in the codec:
     type Transport = Framed<T, LineCodec>;
     type BindTransport = Result<Self::Transport, io::Error>;
     fn bind_transport(&self, io: T) -> Self::BindTransport {

--- a/content/docs/going-deeper-futures/futures-model.md
+++ b/content/docs/going-deeper-futures/futures-model.md
@@ -48,10 +48,10 @@ trait Future {
 type Poll<T, E> = Result<Async<T>, E>;
 
 enum Async<T> {
-    /// Represents that a value is immediately ready.
+    // Represents that a value is immediately ready.
     Ready(T),
 
-    /// Represents that a value is not ready yet, but may be so later.
+    // Represents that a value is not ready yet, but may be so later.
     NotReady,
 }
 ```
@@ -142,11 +142,11 @@ Completing the analogy with threads, tasks provide a [`current`]/[`notify`] API 
 "blocking" and wakeup:
 
 ```rust,ignore
-/// Returns a handle to the current task to call notify at a later date.
+// Returns a handle to the current task to call notify at a later date.
 fn current() -> Task;
 
 impl Task {
-    /// Indicate that the task should attempt to poll its future in a timely fashion.
+    // Indicate that the task should attempt to poll its future in a timely fashion.
     fn notify(&self);
 }
 ```
@@ -349,14 +349,14 @@ trait Sink {
 type StartSend<T, E> = Result<AsyncSink<T>, E>;
 
 enum AsyncSink<T> {
-    /// The `start_send` attempt succeeded, so the sending process has
-    /// *started*; you must use `Sink::poll_complete` to drive the send
-    /// to completion.
+    // The `start_send` attempt succeeded, so the sending process has
+    // *started*; you must use `Sink::poll_complete` to drive the send
+    // to completion.
     Ready,
 
-    /// The `start_send` attempt failed due to the sink being full. The
-    /// value being sent is returned, and the current `Task` will be
-    /// automatically notified again once the sink has room.
+    // The `start_send` attempt failed due to the sink being full. The
+    // value being sent is returned, and the current `Task` will be
+    // automatically notified again once the sink has room.
     NotReady(T),
 }
 ```

--- a/content/docs/going-deeper-tokio/transports.md
+++ b/content/docs/going-deeper-tokio/transports.md
@@ -176,7 +176,7 @@ struct PingPong<T> {
     upstream: T,
 }
 
-/// Implement `Stream` for our transport ping / pong middleware
+// Implement `Stream` for our transport ping / pong middleware
 impl<T> Stream for PingPong<T>
     where T: Stream<Item = String, Error = io::Error>,
           T: Sink<SinkItem = String, SinkError = io::Error>,


### PR DESCRIPTION
Most of the documentation uses regular comments except for several occurrences of doc comments and seems like there is no reason for later (because documentation is not going to get it's own documentation).