### PR TITLE
Fix links to Stream::and_then and Sink::send_all methods in "Pipeline server"

### DIFF
--- a/content/docs/getting-started/pipeline-server.md
+++ b/content/docs/getting-started/pipeline-server.md
@@ -172,7 +172,7 @@ responses if they are available. The key is that [`Sink::send_all`] eager
 pulls as many elements from the stream as it can, writing them all into the
 sink, flushing only at the end.
 
-[`Stream::and_then`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html#method.send_all
+[`Stream::and_then`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html#method.and_then
 [`Sink::send_all`]: https://docs.rs/futures/0.1/futures/sink/trait.Sink.html#method.send_all
 
 To complete the example, let's build one final echo service and plug them together:

--- a/content/docs/getting-started/pipeline-server.md
+++ b/content/docs/getting-started/pipeline-server.md
@@ -166,13 +166,14 @@ handle.spawn(server);
 ```
 
 And that's it---we've built a general-purpose server for a line-based
-protocol. By using the built-in framing and [`Stream::send_all`] method, we also
+protocol. By using the built-in framing and [`Sink::send_all`] method, we also
 get a pretty efficient server: it will batch up handling multiple requests and
-responses if they are available. The key is that [`Stream::send_all`] eager
+responses if they are available. The key is that [`Sink::send_all`] eager
 pulls as many elements from the stream as it can, writing them all into the
 sink, flushing only at the end.
 
 [`Stream::and_then`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html#method.send_all
+[`Sink::send_all`]: https://docs.rs/futures/0.1/futures/sink/trait.Sink.html#method.send_all
 
 To complete the example, let's build one final echo service and plug them together:
 


### PR DESCRIPTION
Change method `Stream::send_all` to `Sink::send_all` and add link
Fix link for `Stream::and_then` method