### PR TITLE
fixed typo in dependency list

### DIFF
--- a/content/docs/getting-started/chat.md
+++ b/content/docs/getting-started/chat.md
@@ -35,7 +35,7 @@ Next, add the necessary dependencies:
 ```toml
 [dependencies]
 tokio = "0.1"
-tokio_io = "0.1"
+tokio-io = "0.1"
 futures = "0.1"
 bytes = "0.4"
 ```


### PR DESCRIPTION
tokio_io is the old name. The crate is now called tokio-io.