### PR TITLE
Deterministically order blog menu

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -15,7 +15,7 @@
       <nav class="leftnav">
         <div class="" id="">
           <ul class="nav">
-            {{ range .Site.Menus.blog.Reverse }}
+            {{ range .Site.Menus.blog.ByWeight.Reverse }}
             <li class="active">
               <a href="{{ .URL }}" {{ if not (eq $currentURL .URL) }}class="text-muted"{{ end }}>{{ .Name }}</a>
             </li>


### PR DESCRIPTION
Calling reverse on Site Menu with out sorting it lead to strange
behaviour.  The menu order is not the same on every blog page.

I was unable to figure out a way to order by date, so this orders it by
weight.

Thanks @Yoopo for pointing out the issue.