### PR TITLE
Update for the runtime release

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -4,8 +4,8 @@ set -ex
 if [ ! -d tmp ]; then
   cargo new tmp
   cat >> tmp/Cargo.toml <<-EOF
-futures = "0.1"
-tokio = { git = "https://github.com/tokio-rs/tokio" }
+futures = "0.1.18"
+tokio = "0.1.2"
 
 # Legacy deps
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,8 +5,7 @@ if [ ! -d tmp ]; then
   cargo new tmp
   cat >> tmp/Cargo.toml <<-EOF
 futures = "0.1"
-tokio = "0.1"
-tokio-io = "0.1"
+tokio = { git = "https://github.com/tokio-rs/tokio" }
 
 # Legacy deps
 

--- a/content/blog/2018-03-tokio-runtime.md
+++ b/content/blog/2018-03-tokio-runtime.md
@@ -52,6 +52,33 @@ strategy as Go, Erlang, .NET, Java (the ForkJoin pool), etc... The
 implementation provided by Tokio is designed for use cases where many
 **unrelated** tasks are multiplexed on a single thread pool.
 
+## Using the Tokio Runtime
+
+As illustrated in the example above, the easiest way to use the Tokio runtime
+is with two functions:
+
+* `tokio::run`
+* `tokio::spawn`.
+
+The first function takes a future to seed the application and starts the
+runtime. Roughly, it does the following:
+
+1) Start the reactor.
+2) Start the thread pool.
+3) Spawn the future onto the thread pool.
+4) Blocks the thread until the runtime becomes idle.
+
+The runtime becomes idle once **all** spawned futures have completed and **all**
+I/O resources bound to the reactor are dropped.
+
+From within the context of a runtime. The application may spawn additional
+futures onto the thread pool using `tokio::spawn`.
+
+Alternatively, the [`Runtime`] type can be used directly. This allows for more
+flexibility around setting up and using the runtime.
+
+[`Runtime`]: #
+
 ## Future improvements
 
 This is just the initial release of the Tokio runtime. Upcoming releases will

--- a/content/blog/2018-03-tokio-runtime.md
+++ b/content/blog/2018-03-tokio-runtime.md
@@ -13,7 +13,7 @@ iteration of the Tokio Runtime.
 
 This is how a multi-threaded Tokio based server is now written:
 
-```rust
+```rust,ignore
 extern crate tokio;
 
 use tokio::net::TcpListener;

--- a/content/blog/2018-03-tokio-runtime.md
+++ b/content/blog/2018-03-tokio-runtime.md
@@ -1,0 +1,77 @@
++++
+date = "2018-03-08"
+title = "Announcing the Tokio runtime"
+description = "08 March 2018"
+menu = "blog"
+weight = 104
++++
+
+I'm happy to announce a new release of Tokio. This release includes the first
+iteration of the Tokio Runtime.
+
+## tl;dr
+
+This is how a multi-threaded Tokio based server is now written:
+
+```rust
+extern crate tokio;
+
+use tokio::net::TcpListener;
+use tokio::prelude::*;
+
+let addr = "127.0.0.1:8080".parse().unwrap();
+let listener = TcpListener::bind(&addr).unwrap();
+
+let server = listener.incoming()
+    .map_err(|e| println!("error = {:?}", e))
+    .for_each(|socket| {
+        tokio::spawn(process(socket))
+    });
+
+tokio::run(server);
+```
+
+## What is the Tokio Runtime?
+
+The Rust asynchronous stack is evolving to a set of loosely coupled components.
+To get a basic networking application running, you need at a minimum an
+asynchronous task executor and an instance of the Tokio reactor. Because
+everything is decoupled, there are multiple options for these various
+components, but this adds a bunch of boilerplate to all apps.
+
+To help mitigate this, Tokio now provides the concept of a runtime. This is a
+pre-configured package of all the various components that are necessary for
+running the application.
+
+This initial release of the runtime includes the reactor as well as a
+[work-stealing] based thread pool for scheduling and executing the application's
+code. This provides a multi-threaded default for applications.
+
+The work-stealing default is ideal for most applications. It uses a similar
+strategy as Go, Erlang, .NET, Java (the ForkJoin pool), etc... The
+implementation provided by Tokio is designed for use cases where many
+**unrelated** tasks are multiplexed on a single thread pool.
+
+## Future improvements
+
+This is just the initial release of the Tokio runtime. Upcoming releases will
+include additional functionality that is useful for Tokio based applications. A
+blog post will be coming soon that goes into the roadmap in more detail.
+
+The goal, as mentioned before, is to release early and often. Providing new
+features to enable the community to experiment with them. Sometime in the next
+few months, there will be a breaking release of the entire Tokio stack, so any
+changes in the API need to be discovered before then.
+
+## Tokio-core
+
+There has also been a new release of `tokio-core`. This release updates
+`tokio-core` to use `tokio` under the hood. This enables all existing
+applications and libraries that currently depend on `tokio-core` (like Hyper) to
+be able to use the improvements that come with the Tokio runtime without
+requiring a breaking change.
+
+Given the amount of churn that is expected to happen in the next few months,
+we're hoping to help ease the transition across releases.
+
+[work-stealing]: https://en.wikipedia.org/wiki/Work_stealing

--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -6,7 +6,11 @@ weight = 130
 +++
 
 Futures, hinted at earlier in the guide, are the building block used to manage
-asynchronous logic. They are the foundation of a Tokio based application.
+asynchronous logic. They are the underlying asynchronous abstraction used by
+Tokio.
+
+The future implementation is provided by the [`futures`] crate. However, for
+convenience, Tokio re-exports a number of the types.
 
 ## [What Are Futures?](#what-are-futures) {#what-are-futures}
 

--- a/content/docs/getting-started/runtime-model.md
+++ b/content/docs/getting-started/runtime-model.md
@@ -132,9 +132,9 @@ This is the job of an executor.
 
 Executors are responsible for repeatedly calling `poll` on a task until `Ready`
 is returned. There are many different ways to do this. For example, the
-[`current_thread`] executor will block the current thread and loop through all
-spawned tasks, calling poll on them. [`CpuPool`] schedules tasks across a thread
-pool.
+[`CurrentThread`] executor will block the current thread and loop through all
+spawned tasks, calling poll on them. [`ThreadPool`] schedules tasks across a thread
+pool. This is also the default executor used by the [runtime][rt].
 
 All tasks **must** be spawned on an executor or no work will be performed.
 
@@ -225,5 +225,6 @@ core of the [`futures`] task model. We will be digging more into that shortly.
 [`TcpStream`]: {{< api-url "tokio" >}}/net/struct.TcpStream.html
 [`Async`]: {{< api-url "futures" >}}/enum.Async.html
 [`Future`]: {{< api-url "futures" >}}/future/trait.Future.html
-[`current_thread`]: {{< api-url "tokio" >}}/executor/current_thread/index.html
-[`CpuPool`]: http://docs.rs/futures-cpupool
+[`CurrentThread`]: {{< api-url "tokio" >}}/executor/current_thread/index.html
+[`ThreadPool`]: http://docs.rs/tokio-threadpool
+[rt]: {{< api-url "tokio" >}}/runtime/index.html

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -43,14 +43,11 @@
       <div class="tk-content">
         <pre>
 <code>// A tiny async echo server with Tokio
-extern crate futures;
 extern crate tokio;
-extern crate tokio_io;
 
-use futures::{Future, Stream};
-use tokio::executor::current_thread;
+use tokio::io;
 use tokio::net::TcpListener;
-use tokio_io::{io, AsyncRead};
+use tokio::prelude::*;
 
 fn main() {
     // Bind the server's socket
@@ -74,7 +71,7 @@ fn main() {
             });
 
         // Spawn the future as a concurrent task
-        current_thread::spawn(conn);
+        tokio::spawn(conn);
 
         Ok(())
     })
@@ -82,10 +79,8 @@ fn main() {
         println!("server error {:?}", err);
     });
 
-    // Spin up the server on the event loop
-    current_thread::run(|_| {
-        current_thread::spawn(server);
-    });
+    // Start the runtime and spin up the server
+    tokio::run(server);
 }
 </code>
         </pre>


### PR DESCRIPTION
This patch updates the website to use the Tokio runtime instead of
`current_thread`.