### PR TITLE
Correct runtime of Interval example

### DIFF
--- a/content/docs/going-deeper/timers.md
+++ b/content/docs/going-deeper/timers.md
@@ -144,7 +144,7 @@ first fire).
 
 By default, an `Instant` stream is unbounded, i.e., it will continue yielding at
 the requested interval forever. The example uses `Stream::take` to limit the
-number of times `Interval` yields to 10. So, the example will run for 9 seconds
+number of times `Interval` yields to 10. So, the example will run for 0.9 seconds
 since the first of 10 values is yielded immediately.
 
 ## [Notes on the timer](#timer) {#timer}


### PR DESCRIPTION
Since the Interval is 100 milliseconds and there are 9 such intervals, I think that the total time will be 0.9 seconds, not 9 seconds.