### PR TITLE
Simplify finding line delimeter position

### DIFF
--- a/content/docs/getting-started/chat.md
+++ b/content/docs/getting-started/chat.md
@@ -283,9 +283,8 @@ impl Stream for Lines {
         let sock_closed = self.fill_read_buf()?.is_ready();
 
         // Now, try finding lines
-        let pos = self.rd.windows(2).enumerate()
-            .find(|&(_, bytes)| bytes == b"\r\n")
-            .map(|(i, _)| i);
+        let pos = self.rd.windows(2)
+            .position(|bytes| bytes == b"\r\n");
 
         if let Some(pos) = pos {
             // Remove the line from the read buffer and set it


### PR DESCRIPTION
Using `position` method of trait `Iterator` instead of combination of `enumerate`, `find` and `map` methods.

```rust
let pos = self.rd.windows(2)
            .position(|bytes| bytes == b"\r\n");
```