### PR TITLE
Update docs.rs futures link to use futures@0.1

### DIFF
--- a/content/legacy/getting-started/tokio.md
+++ b/content/legacy/getting-started/tokio.md
@@ -28,4 +28,4 @@ with the guide as well.
 
 [`tokio-proto`]: https://docs.rs/tokio-proto
 [`tokio-core`]: https://docs.rs/tokio-core
-[`futures`]: https://docs.rs/futures
+[`futures`]: https://docs.rs/futures/0.1

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -50,7 +50,7 @@
                 <a href="https://docs.rs/tokio" class="text-muted"><code>tokio</code> API docs</a>
               </li>
               <li class="active">
-                <a href="https://docs.rs/futures" class="text-muted"><code>futures</code> API docs</a>
+                <a href="https://docs.rs/futures/0.1" class="text-muted"><code>futures</code> API docs</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Tokio uses the futures library at futures version 0.1. The sidebar in
the documentation section, however, confusingly pointed to futures
version 0.2. Update the link.

I also checked if there were any other locations where futures was
linked to not using 0.1 explicitely with the following command

    grep -rP 'docs.rs/futures(?!/0.1)'

and changed a legacy document, but everything else looks like it is
explicitely linking to the 0.1 version of the docs.