### PR TITLE
change tokio_io::codec to tokio_codec in the tutorial

### DIFF
--- a/content/docs/going-deeper/frames.md
+++ b/content/docs/going-deeper/frames.md
@@ -16,9 +16,9 @@ a stream of line delimited messages with tokio.
 
 ## Writing a codec
 
-The codec implements the `tokio_io::codec::Decoder` and
-`tokio_io::codec::Encoder` traits. Its job is to convert a frame to and from
-bytes. Those traits are used in conjunction with the `tokio_io::codec::Framed`
+The codec implements the `tokio_codec::Decoder` and
+`tokio_codec::Encoder` traits. Its job is to convert a frame to and from
+bytes. Those traits are used in conjunction with the `tokio_codec::Framed`
 struct to provide buffering, decoding and encoding of byte streams.
 
 Let's look at a simplified version of the `LinesCodec` struct, which implements


### PR DESCRIPTION
Although `tokio_io::codec` works, it is confusing to point people to that because the [docs.rs website for tokio_io](https://docs.rs/tokio-io/0.1.7/tokio_io/) says that there is no `codec` module in `tokio_io`. When I was going through the tutorial this morning, I read this part and wanted to look at the documentation for these traits, but eventually had to go looking through the git history for tokio to find out what was wrong.