### PR TITLE
Fix local website build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: rust
 sudo: false
 
 install:
-  - curl -L https://github.com/spf13/hugo/releases/download/v0.18.1/hugo_0.18.1_Linux-64bit.tar.gz |
+  - curl -L https://github.com/gohugoio/hugo/releases/download/v0.47.1/hugo_0.47.1_Linux-64bit.tar.gz |
       tar xzvf -
   - pip install --user awscli
   - ~/.local/bin/aws configure set preview.cloudfront true
 
 script:
   - ci/test.sh
-  - ./hugo_0.18.1_linux_amd64/hugo_0.18.1_linux_amd64
+  - ./hugo
 
 env:
   global:

--- a/content/legacy/going-deeper-tokio/core-low-level.md
+++ b/content/legacy/going-deeper-tokio/core-low-level.md
@@ -51,7 +51,7 @@ for there to be room to write, they will return `WouldBlock`.
 The second property though is a little more subtle. It transitively implies
 that **all Tokio I/O objects can only be used within the context of a task**,
 which generally means within `poll`-like methods. (This task context is tracked
-implicitly using thread-local storage; see the [section on tasks]({{< relref "tasks.md" >}})
+implicitly using thread-local storage; see the [section on tasks]({{< relref "/docs/getting-started/tasks.md" >}})
 for more detail.) With this property, though, we can get ergonomic and efficient
 management of "blocking" the current *task* waiting for I/O to complete. In
 other words, we get a lightweight threading model.


### PR DESCRIPTION
The issue stems from a file in the legacy directory which does not seem to be a part of the current website. I made the link into an absolute link to fix the issue. There are several other warnings regarding the same issue, but not being familiar with Hugo, I couldn't make a lot of headway with it.

But this fix should allow building the website on the latest version of Hugo.

Fixes #190 