### PR TITLE
Update to latest version of hugo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: rust
 sudo: false
 
 install:
-  - curl -L https://github.com/spf13/hugo/releases/download/v0.18.1/hugo_0.18.1_Linux-64bit.tar.gz |
+  - curl -L https://github.com/gohugoio/hugo/releases/download/v0.47.1/hugo_0.47.1_Linux-64bit.tar.gz |
       tar xzvf -
   - pip install --user awscli
   - ~/.local/bin/aws configure set preview.cloudfront true
 
 script:
   - ci/test.sh
-  - ./hugo_0.18.1_linux_amd64/hugo_0.18.1_linux_amd64
+  - ./hugo
 
 env:
   global:


### PR DESCRIPTION
Looks like the `hugo` binary from the latest release just has the name `hugo` on untarring. 

* Made changes to travis.yml to run CI

Blocks #191 