### PR TITLE
Fix "next" link order

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,10 +7,6 @@ googleAnalytics: "UA-90234741-1"
 
 menu:
   docs:
-    - identifier: "overview"
-      name: "Overview"
-      weight: 1
-      url: "/docs/overview"
     - identifier: "getting_started"
       name: "Getting started"
       weight: 1000

--- a/content/docs/getting-started/chat.md
+++ b/content/docs/getting-started/chat.md
@@ -1,9 +1,9 @@
 ---
 title: "Example: A Chat Server"
+weight : 1060
 menu:
   docs:
     parent: getting_started
-    weight : 1060
 ---
 
 We're going to use what has been covered so far to build a chat server. This is

--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -1,9 +1,9 @@
 ---
 title: "Futures"
+weight : 1030
 menu:
   docs:
     parent: getting_started
-    weight : 1030
 ---
 
 Futures, hinted at earlier in the guide, are the building block used to manage

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -1,9 +1,9 @@
 ---
 title: "Hello World!"
+weight : 1010
 menu:
   docs:
     parent: getting_started
-    weight : 1010
 ---
 
 To kick off our tour of Tokio, we will start with the obligatory "hello world"

--- a/content/docs/getting-started/io.md
+++ b/content/docs/getting-started/io.md
@@ -1,9 +1,9 @@
 ---
 title: "I/O with Tokio"
+weight : 1050
 menu:
   docs:
     parent: getting_started
-    weight : 1050
 ---
 
 The [`tokio`] crate comes with TCP and UDP networking types. Unlike the types in

--- a/content/docs/getting-started/runtime-model.md
+++ b/content/docs/getting-started/runtime-model.md
@@ -1,9 +1,9 @@
 ---
 title: "Runtime Model"
+weight : 1020
 menu:
   docs:
     parent: getting_started
-    weight : 1020
 ---
 
 Now we will go over the Tokio / futures runtime model. Tokio is built on top of

--- a/content/docs/getting-started/tasks.md
+++ b/content/docs/getting-started/tasks.md
@@ -1,9 +1,9 @@
 ---
 title: "Tasks"
+weight : 1040
 menu:
   docs:
     parent: getting_started
-    weight : 1040
 ---
 
 Tasks are the application's "unit of logic". They are similar to [Go's

--- a/content/docs/going-deeper/building-runtime.md
+++ b/content/docs/going-deeper/building-runtime.md
@@ -1,9 +1,9 @@
 ---
 title: "Building a runtime"
+weight: 2050
 menu:
   docs:
     parent: going_deeper
-    weight: 2050
 ---
 
 The runtime ‒ all the pieces needed to run an event driven application ‒ is

--- a/content/docs/going-deeper/frames.md
+++ b/content/docs/going-deeper/frames.md
@@ -1,9 +1,9 @@
 ---
 title: "Working with framed streams"
+weight: 2040
 menu:
   docs:
     parent: going_deeper
-    weight: 2040
 ---
 
 Tokio has helpers to transform a stream of bytes into a stream of frames. Examples

--- a/content/docs/going-deeper/futures-mechanics.md
+++ b/content/docs/going-deeper/futures-mechanics.md
@@ -1,9 +1,9 @@
 ---
 title: "Essential combinators"
+weight: 2020
 menu:
   docs:
     parent: going_deeper
-    weight: 2020
 ---
 
 We saw a few of the most important combinators in the

--- a/content/docs/going-deeper/returning.md
+++ b/content/docs/going-deeper/returning.md
@@ -1,9 +1,9 @@
 ---
 title: "Returning futures"
+weight: 2030
 menu:
   docs:
     parent: going_deeper
-    weight: 2030
 ---
 
 [`Future`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html

--- a/content/docs/going-deeper/timers.md
+++ b/content/docs/going-deeper/timers.md
@@ -1,9 +1,9 @@
 ---
 title: "Timers"
+weight: 2010
 menu:
   docs:
     parent: going_deeper
-    weight: 2010
 ---
 
 When writing a network based application, it is common to need to perform

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1,6 +1,7 @@
 ---
 title: "Overview"
 weight: 1
+menu: "docs"
 ---
 
 Tokio is an event-driven, non-blocking I/O platform for writing

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -56,7 +56,8 @@
       </div>
       <h1 class="tk-title">{{ .Title }}</h1>
       {{ .Content }}
-      {{ with .Next }}
+      <!-- Yes prev... because hugo bugs -->
+      {{ with .PrevInSection }}
         <div class="tk-next">
           <b>Next up</b>: <a href ="{{ .URL }}">{{ .Title }}</a>
         </div>


### PR DESCRIPTION
The "next" link order in the guides broke with the refresh.