### PR TITLE
Internals doc

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,9 @@ menu:
     - identifier: "going_deeper"
       name: "Going deeper"
       weight: 2000
+    - identifier: "internals"
+      name: "Tokio internals"
+      weight: 8000
     - identifier: "reference"
       name: "API documentation"
       url: "https://docs.rs/tokio"

--- a/content/docs/internals/intro.md
+++ b/content/docs/internals/intro.md
@@ -1,0 +1,21 @@
+---
+title: "Introduction"
+menu:
+  docs:
+    parent: "internals"
+    weight: 8001
+---
+
+This document provides an in depth guide of the internals of Tokio, the various
+components, and how they fit together. It expects that the reader already has a
+fairly good understanding of how to use Tokio. A [getting started][guide] guide
+is provided on the website.
+
+[guide]: {{< ref "/docs/getting-started/hello-world.md" >}}
+
+# Contents
+
+* [Runtime model]({{< relref "runtime-model.md" >}}) - An overview of Tokio's
+  asynchronous runtime model.
+* [Non-blocking I/O]({{<relref "net.md" >}}) - Implementation details of Tokio's
+  network related types (TCP, UDP, ...).

--- a/content/docs/internals/intro.md
+++ b/content/docs/internals/intro.md
@@ -1,19 +1,16 @@
 ---
 title: "Introduction"
+weight: 8001
 menu:
   docs:
     parent: "internals"
-    weight: 8001
 ---
 
-This document provides an in depth guide of the internals of Tokio, the various
-components, and how they fit together. It expects that the reader already has a
-fairly good understanding of how to use Tokio. A [getting started][guide] guide
-is provided on the website.
+The internals section provides an in-depth guide of Tokio's internals. It
+expects the reader already has a good understanding of how to use Tokio. Those
+unfamiliar with Tokio should start with the [getting started][guide] guide.
 
 [guide]: {{< ref "/docs/getting-started/hello-world.md" >}}
-
-# Contents
 
 * [Runtime model]({{< relref "runtime-model.md" >}}) - An overview of Tokio's
   asynchronous runtime model.

--- a/content/docs/internals/net.md
+++ b/content/docs/internals/net.md
@@ -1,9 +1,9 @@
 ---
 title: "Non-blocking I/O"
+weight: 8020
 menu:
   docs:
     parent: "internals"
-    weight: 8020
 ---
 
 This section describes the network resources and drivers provided by Tokio. This
@@ -25,8 +25,8 @@ composed of the network handle and a reference to the [driver] that is powering
 the resource. Initially, when the resource is first created, the driver pointer
 may be `None`:
 
-[driver]: #
-[`Evented`]: #
+[driver]: #the-network-driver
+[`Evented`]: https://docs.rs/mio/0.6/mio/event/trait.Evented.html
 
 ```rust
 let listener = TcpListener::bind(&addr).unwrap();
@@ -414,7 +414,7 @@ the task runs again, it will call the `poll_accept` function again. This time,
 the `task` slot will be `None`. This means the syscall should be attempted, and
 this time `poll_accept` will return an accepted socket (probably, spurious events are permitted).
 
-[`Runtime`]: #
-[`Park`]: #
+[`Runtime`]: https://docs.rs/tokio/0.1/tokio/runtime/struct.Runtime.html
+[`Park`]: https://docs.rs/tokio-executor/0.1/tokio_executor/park/trait.Park.html
 [real-impl]: https://github.com/tokio-rs/tokio/blob/master/tokio-reactor/src/lib.rs
-[runtime guide]: #
+[runtime guide]: {{< relref "/docs/going-deeper/building-runtime.md" >}}

--- a/content/docs/internals/net.md
+++ b/content/docs/internals/net.md
@@ -1,0 +1,420 @@
+---
+title: "Non-blocking I/O"
+menu:
+  docs:
+    parent: "internals"
+    weight: 8020
+---
+
+This section describes the network resources and drivers provided by Tokio. This
+component provides one of Tokio's primary functions: non-blocking, event-driven,
+networking provided by the appropriate operating system primitives (epoll,
+kqueue, IOCP, ...). It is modeled after the resource and driver pattern
+described in the previous section.
+
+The network driver is built using [mio] and network resources are backed by
+types that implement [`Evented`].
+
+This guide will be focused on TCP types. The other network resources (UDP, unix
+sockets, pipes, etc) follow the same pattern.
+
+# The network resource.
+
+Network resources are types, such as [`TcpListener`] and [`TcpStream`], that are
+composed of the network handle and a reference to the [driver] that is powering
+the resource. Initially, when the resource is first created, the driver pointer
+may be `None`:
+
+[driver]: #
+[`Evented`]: #
+
+```rust
+let listener = TcpListener::bind(&addr).unwrap();
+```
+
+In this case, the reference to the driver is not yet set. However, if a
+constructor that takes a [`Handle`] reference is used, then the driver reference
+will be set to driver represented by the given handle:
+
+```rust
+let listener = TcpListener::from_std(std_listener, &my_reactor_handle);
+```
+
+Once a driver is associated with a resource, it is set for the lifetime of the
+resource and cannot be changed. The associated driver is responsible for
+receiving operating system events for the network resource and notifying the
+tasks that have expressed interest in the resource.
+
+## Using the resource
+
+Resource types include non-blocking functions that are prefixed with `poll_` and
+that include `Async` in the return type. These are the functions that are linked
+with the task system and should be used from tasks and are used as part of
+[`Future`] implementations. For example, [`TcpStream`] provides [`poll_read`] and
+[`poll_write`]. [`TcpListener`] provides [`poll_accept`].
+
+Here is a task that uses [`poll_accept`] to accept inbound sockets from a
+listener and handle them by spawning a new task:
+
+```rust
+struct Acceptor {
+    listener: TcpListener,
+}
+
+impl Future for Acceptor {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            let (socket, _) = try_ready!(self.listener.poll_accept());
+
+            // Spawn a task to process the socket
+            tokio::spawn(process(socket));
+        }
+    }
+}
+```
+
+Resource types may also include functions that return futures. These are
+helpers that use the `poll_` functions to provide additional functionality. For
+example, [`TcpStream`] provides a [`connect`] function that returns a future.
+This future will complete once the [`TcpStream`] has established a connection
+with a peer (or failed attemepting to do so).
+
+Using combinators to connect a [`TcpStream`]:
+
+```rust
+tokio::spawn({
+    let connect_future = TcpStream::connect(&addr);
+
+    connect_future
+        .and_then(|socket| process(socket))
+});
+```
+
+Futures may also be used directly from other future implementations:
+
+```rust
+struct ConnectAndProcess {
+    connect: ConnectFuture,
+}
+
+impl Future for ConnectAndProcess {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let socket = try_ready!(self.connect.poll());
+        tokio::spawn(process(socket));
+        Ok(Async::Ready(()))
+    }
+}
+```
+
+# Registering the resource with the driver
+
+When using [`TcpListener::poll_accept`][poll_accept] (or any `poll_*` function),
+if the resource is ready to return immediately then it will do so. In the case
+of [`poll_accept`][poll_accept], being ready means that there is a socket
+waiting to be accepted in the queue. If the resource is **not** ready, i.e.
+there is no pending socket to accept, then the resource asks the driver to
+notify the current task once it becomes ready.
+
+The first time `NotReady` is returned by a resource, if the resource was not
+explicity assigned a driver using a [`Handle`] argument, the resource will register
+itself with a driver instance. This is done by looking at the network driver
+associated with the current execution context.
+
+The default driver for the execution context is stored using a thread-local, set
+using [`with_default`], and accessed using [`Handle::current`]. It is the
+runtime's responsibility to ensure that the task is polled from within the
+closure passed to [`with_default`]. A call to [`Handle::current`] accesses the
+thread-local set by [`with_default`] in order to return the handle to the
+driver for the current execution context.
+
+## `Handle::current` vs `Handle::default`
+
+Both `Handle::current` and `Handle::default` return a `Handle` instance.
+They are, however, subtly different. Most often, `Handle::default` is the
+desired behavior.
+
+`Handle::current` **immediately** reads the thread-local variable storing the
+driver for the current driver. This means that `Handle::current` must be called
+from an execution context that set the default driver. `Handle::current` should
+be used when the handle is going to be sent to a different execution contexts
+and the user wishes that a specific reactor is used (see below for an example).
+
+On the other hand, [`Handle::default`] lazily reads the thread-local variable.
+This allows getting a `Handle` instance from *outside* of an execution context.
+When the resource is used, the handle will access the thread-local variable as
+described in the previous section.
+
+For example:
+
+```rust
+fn main() {
+    let std_listener = ::std::net::TcpListener::bind(&addr);
+    let listener = TcpListener::from_std(std_listener, &Handle::default());
+
+    tokio::run({
+        listener.incoming().for_each(|socket| {
+            tokio::spawn(process(socket));
+            Ok(())
+        })
+    });
+}
+```
+
+In this example, `incoming()` returns a future that is implemented by calling
+`poll_accept`. The future is spawned onto a runtime, which has a network driver
+configured as part of the execution context. When `poll_accept` is called from
+within the execution context, that is when the thread-local is read and the
+driver is associated with the `TcpListener` instance.
+
+However, if `tokio-threadpool` is used directly, then tasks spawned onto the
+threadpool executor will not have access to a reactor:
+
+```rust
+let pool = ThreadPool::new();
+let listener = TcpListener::bind(&addr).unwrap();
+
+pool.spawn({
+    listener.incoming().for_each(|socket| {
+        // This will never get called due to the listener not being able to
+        // function.
+        unreachable!();
+    })
+});
+```
+
+In order to make the above example work, a reactor must be set for the
+threadpool's execution context. See [building a runtime][building] for more
+details. Alternatively, a `Handle` obtained with `[Handle::current]` could be
+used:
+
+```rust
+let pool = ThreadPool::new();
+
+// This does not run on the pool.
+tokio::run(lazy(|| {
+    // Get the handle
+    let handle = Handle::current();
+
+    let std_listener = std::net::TcpListener::bind(&addr);
+
+    // This eagerly links the listener with the handle for the current reactor.
+    let listener = TcpListener::from_std(std_listener, &handle).unwrap();
+
+    pool.spawn({
+        listener.incoming().for_each(|socket| {
+            // Do something with the socket
+            Ok(())
+        })
+    });
+
+    Ok(())
+}));
+```
+
+[`TcpStream`]: https://docs.rs/tokio/0.1/tokio/net/struct.TcpStream.html
+[`TcpListener`]: https://docs.rs/tokio/0.1/tokio/net/struct.TcpListener.html
+[`Handle`]: https://docs.rs/tokio-reactor/0.1/tokio_reactor/struct.Handle.html
+[poll_accept]: http://docs.rs/tokio/0.1.8/tokio/net/struct.TcpListener.html#method.poll_accept
+[`with_default`]: https://docs.rs/tokio-reactor/0.1.5/tokio_reactor/fn.with_default.html
+[`Handle::default`]: https://docs.rs/tokio-reactor/0.1.5/tokio_reactor/struct.Handle.html#method.default
+[building]: https://tokio.rs/docs/going-deeper/building-runtime/
+
+# The network driver
+
+The driver that powers all of Tokio's network types is the [`Reactor`] type in
+the [`tokio-reactor`] crate. It is implemented using [mio]. Calls to
+[`Reactor::turn`] uses [`mio::Poll::poll`] to get operating system events for
+registered network resources. It then notifies the registered tasks for each
+network resource using the [task system]. The tasks then get scheduled to run on
+their associated executors and the task then sees the network resource as ready
+and calls to `poll_*` functions return `Async::Ready`.
+
+## Linking the driver with resources
+
+The driver must track each resource that is registered with it. While the actual
+implementation is more complex, it can be thought as a shared reference to a
+cell sharing state, similar to:
+
+```rust
+struct Registration {
+    // The registration needs to know its ID. This allows it to remove state
+    // from the reactor when it is dropped.
+    id: Id,
+
+    // The task that owns the resource and is registered to receive readiness
+    // notifications from the driver.
+    //
+    // If `task` is `Some`, we **definitely** know that the resource
+    // is not ready because we have not yet received an operating system event.
+    // This allows avoiding syscalls that will return `NotReady`.
+    //
+    // If `task` is `None`, then the resource **might** be ready. We can try the
+    // syscall, but it might still return `NotReady`.
+    task: Option<task::Task>,
+}
+
+struct TcpListener {
+    mio_listener: mio::TcpListener,
+    registration: Option<Arc<Mutex<Registration>>>,
+}
+
+struct Reactor {
+    poll: mio::Poll,
+    resources: HashMap<Id, Arc<Mutex<Registration>>>,
+}
+```
+
+**This is not the real implementation**, but a simplified version to demonstrate
+the behavior. In practice, there is no `Mutex`, cells are not allocated per
+resource instance, and the reactor does not use a `HashMap`. The real
+implementation can be found [here][real-impl]
+
+When the resource is first used, it is registered with the driver:
+
+```rust
+impl TcpListener {
+    fn poll_accept(&mut self) -> Poll<TcpStream, io::Error> {
+        // If the registration is not set, this will associate the `TcpListener`
+        // with the current execution context's reactor.
+        let registration = self.registration.get_or_insert_with(|| {
+            // Access the thread-local variable that tracks the reactor.
+            Reactor::with_current(|reactor| {
+                // Registers the listener, which implements `mio::Evented`.
+                // `register` returns the registration instance for the resource.
+                reactor.register(&self.mio_listener)
+            })
+        });
+
+        if registration.task.is_none() {
+            // The task is `None`, this means the resource **might** be ready.
+            match self.mio_listener.accept() {
+                Ok(socket) => {
+                    let socket = mio_socket_to_tokio(socket);
+                    return Ok(Async::Ready(socket));
+                }
+                Err(ref e) if e.kind() == WouldBlock => {
+                    // The resource is not ready, fall through to task registration
+                }
+                Err(e) => {
+                    // All other errors are returned to the caller
+                    return Err(e);
+                }
+            }
+        }
+
+        // The task is set even if it is already `Some`, this handles the case where
+        // the resource is moved to a different task than the one stored in
+        // `self.task`.
+        registration.task = Some(task::current());
+        Ok(Async::NotReady)
+    }
+}
+```
+
+Note that there is only a single `task` field per resource. The implications are
+that a resource can only be used from a single task at a time. If
+`TcpListener::poll_accept` returns `NotReady`, registering the current task and
+the listener is then sent to a different task which calls `poll_accept` and sees
+`NotReady`, then the second task is the only one that will receive a
+notification once a socket is ready to be accepted. Resources may support
+tracking different tasks for different operations. For example, `TcpStream`
+internally has two task fields: one for notifying on read ready and one for
+notifying on write ready. This allows `TcpStream::poll_read` and
+`TcpStream::poll_write` to be called from different tasks.
+
+The evented types are registered with the driver's [`mio::Poll`] instance as
+part of the `register` function used above. Again, this guide uses a
+**simplified** implementation which does not match the actual one in
+`tokio-reactor` but is sufficient for understanding how `tokio-reactor` behaves.
+
+```rust
+impl Reactor {
+    fn register<T: mio::Evented>(&mut self, evented: &T) -> Arc<Mutex<Registration>> {
+        // Generate a unique identifier for this registration. This identifier
+        // can be converted to and from a Mio Token.
+        let id = generate_unique_identifier();
+
+        // Register the I/O type with Mio
+        self.poll.register(
+            evented, id.into_token(),
+            mio::Ready::all(),
+            mio::PollOpt::edge());
+
+        let registration = Arc::new(Mutex::new(Registration {
+            id,
+            task: None,
+        }));
+
+        self.resources.insert(id, registration.clone());
+
+        registration
+    }
+}
+```
+
+## Running the driver
+
+The driver needs to run in order for its associated resources to function. If
+the driver does not run, the resources will never become ready. Running the
+driver is handled automatically when using a [`Runtime`], but it is useful to
+understand how it works. If you are interested in the real implementation, the
+[`tokio-reactor`][real-impl] source is the best reference.
+
+When resources are registered with the driver, they are also registered with
+Mio. Running the driver performs the following steps in a loop:
+
+1) Call [`Poll::poll`] to get operating system events.
+2) Dispatch all events to the appropriate resources via the registration.
+
+[`mio::Poll`]: https://docs.rs/mio/0.6/mio/struct.Poll.html
+[`Poll::poll`]: https://docs.rs/mio/0.6/mio/struct.Poll.html#method.poll
+
+The steps above are done by calling `Reactor::turn`. The looping part is up to
+us. This is typically done in a background thread or embedded in the executor as
+a [`Park`] implementation. See the [runtime guide] for more details.
+
+```rust
+loop {
+    // `None` means never timeout, blocking until we receive an operating system
+    // event.
+    reactor.turn(None);
+}
+```
+
+The implementation of `turn` does the following:
+
+```rust
+fn turn(&mut self) {
+    // Create storage for operating system events. This shouldn't be created
+    // each time `turn` is called, but doing so does not impact behavior.
+    let mut events = mio::Events::with_capacity(1024);
+
+    self.poll.poll(&mut events, timeout);
+
+    for event in &events {
+        let id = Id::from_token(event.token());
+
+        if let Some(registration) = self.resources.get(&id) {
+            if let Some(task) = registration.lock().unwrap().task.take() {
+                task.notify();
+            }
+        }
+    }
+}
+```
+
+Notifying the task results in the task getting scheduled on its executor. When
+the task runs again, it will call the `poll_accept` function again. This time,
+the `task` slot will be `None`. This means the syscall should be attempted, and
+this time `poll_accept` will return an accepted socket (probably, spurious events are permitted).
+
+[`Runtime`]: #
+[`Park`]: #
+[real-impl]: https://github.com/tokio-rs/tokio/blob/master/tokio-reactor/src/lib.rs
+[runtime guide]: #

--- a/content/docs/internals/net.md
+++ b/content/docs/internals/net.md
@@ -275,6 +275,7 @@ tokio::run(future::lazy(move || {
 [`TcpStream`]: https://docs.rs/tokio/0.1/tokio/net/struct.TcpStream.html
 [`TcpListener`]: https://docs.rs/tokio/0.1/tokio/net/struct.TcpListener.html
 [`Handle`]: https://docs.rs/tokio-reactor/0.1/tokio_reactor/struct.Handle.html
+[`Handle::current`]: https://docs.rs/tokio/0.1/tokio/reactor/struct.Handle.html#method.current
 [poll_accept]: http://docs.rs/tokio/0.1.8/tokio/net/struct.TcpListener.html#method.poll_accept
 [`with_default`]: https://docs.rs/tokio-reactor/0.1.5/tokio_reactor/fn.with_default.html
 [`Handle::default`]: https://docs.rs/tokio-reactor/0.1.5/tokio_reactor/struct.Handle.html#method.default

--- a/content/docs/internals/runtime-model.md
+++ b/content/docs/internals/runtime-model.md
@@ -1,9 +1,9 @@
 ---
 title: "Runtime model"
+weight: 8010
 menu:
   docs:
     parent: "internals"
-    weight: 8010
 ---
 
 Applications written using Tokio are organized across a large number of small,
@@ -87,8 +87,8 @@ automatically. However, if a task must run a longer computation, it should defer
 work to a [blocking pool] or break up the computation into smaller chunks and
 [yield] back to the executor after each chunk.
 
-[blocking pool]: #
-[yield]: #
+[blocking pool]: https://docs.rs/tokio-threadpool/0.1/tokio_threadpool/fn.blocking.html
+[yield]: #yielding
 
 # Task system
 
@@ -297,8 +297,8 @@ spawn one or more threads and dedicate these threads to draining the `scheduled`
 linked list. Another is to provide a `MyExecutor::run` function that blocks the
 current thread and drains the `scheduled` linked list.
 
-[`current_thread`]: #
-[`thread_pool`]: #
+[`current_thread`]: http://docs.rs/tokio-current-thread
+[`thread_pool`]: https://docs.rs/tokio-threadpool
 [Spawn]: https://docs.rs/futures/0.1/futures/executor/struct.Spawn.html
 [poll_future_notify]: https://docs.rs/futures/0.1/futures/executor/struct.Spawn.html#method.poll_future_notify
 [current]: https://docs.rs/futures/0.1/futures/task/fn.current.html

--- a/content/docs/internals/runtime-model.md
+++ b/content/docs/internals/runtime-model.md
@@ -1,0 +1,365 @@
+---
+title: "Runtime model"
+menu:
+  docs:
+    parent: "internals"
+    weight: 8010
+---
+
+Applications written using Tokio are organized across a large number of small,
+non-blocking tasks. A Tokio task is similar to a [goroutine][goroutine] or an
+[Erlang process][erlang], but is non-blocking. They are designed to be
+lightweight, can be spawned fast, and maintain low scheduling overhead. They are
+also non-blocking, as such operations that are not able to finish immediately
+must still return immediately. Instead of returning the result of the operation,
+they return a value indicating that the operation is in progress.
+
+[goroutine]: https://www.golang-book.com/books/intro/10#section1
+[erlang]: http://erlang.org/doc/reference_manual/processes.html
+
+# Non-blocking execution
+
+A Tokio task is implemented using the [`Future`][Future] trait:
+
+```rust
+struct MyTask {
+    my_resource: MyResource,
+}
+
+impl Future for MyTask {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.my_resource.poll() {
+            Ok(Async::Ready(value)) => {
+                self.process(value);
+                Ok(Async::Ready(()))
+            }
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Err(err) => {
+                self.process_err(err);
+                Ok(Async::Ready(()))
+            }
+        }
+    }
+}
+```
+
+Tasks are submitted to an executor using `tokio::spawn` or by calling a `spawn`
+method on an executor object. The `poll` function drives the task. No work is
+done without calling `poll`. It is the executor's job to call `poll` on the task
+until `Ready(())` is returned.
+
+`MyTask` will receive a value from `my_resource` and process it. Once the value
+has been processed, the task has completed its logic and is done. This is
+represented by returning `Ok(Async::Ready(()))`.
+
+However, in order to complete processing, the task depends on `my_resource`
+providing a value. Given that `my_resource` is a non-blocking task, it may or
+may not be ready to provide the value when `my_resource.poll()` is called. If it
+is ready, it returns `Ok(Async::Ready(value))`. If it is not ready, it returns
+`Ok(Async::NotReady)`.
+
+When the resource is not ready to provide a value, this implies that the task
+itself is not ready to complete and the task's `poll` function returns
+`NotReady` as well.
+
+At some point in the future, the resource will become ready to provide the
+value. The resource uses the task system to signal to the executor that it is
+ready. The executor schedules the task, which leads to `MyTask::poll` being
+called again. This time, given that `my_resource` is ready, the value will be
+returned from `my_resource.poll()` and the task is able to complete.
+
+[Future]: https://docs.rs/futures/0.1/futures/future/trait.Future.html
+
+## Cooperative scheduling
+
+Cooperative scheduling is used to schedule tasks on executors. A single executor
+is expected to manage many tasks across a small set of threads. There will be
+a far greater number of tasks then threads. There also is no pre-emption. This
+means that when a task is scheduled to execute, it blocks the current thread
+until the `poll` function returns.
+
+Because of this, it is important for implementations of `poll` to only execute
+for very short periods of time. For I/O bound applications, this usually happens
+automatically. However, if a task must run a longer computation, it should defer
+work to a [blocking pool] or break up the computation into smaller chunks and
+[yield] back to the executor after each chunk.
+
+[blocking pool]: #
+[yield]: #
+
+# Task system
+
+The task system is the system by which resources notify executors of readiness
+changes. A task is composed of non-blocking logic that consume resources. In the
+example above, `MyTask` uses a single resource, `my_resource`, but there is no
+limit to the number of resources that a task can consume.
+
+When a task is executing and attempts to use a resource that is not ready, it
+becomes *logically* blocked on that resource, i.e., the task is not able to make
+further progress until that resource becomes ready. Tokio tracks which resources
+a task is currently blocked on to make forward progress. When a dependent
+resource becomes ready, the executor schedules the task. This is done by
+tracking when a task **expresses interest** in a resource.
+
+When `MyTask` executes, attempts to consume `my_resource`, and `my_resource`
+returns `NotReady`, `MyTask` has implicitly expressed interest in the
+`my_resource` resource. At this point the task and the resource are linked. When
+the resource becomes ready, the task is scheduled again.
+
+## `task::current` and `Task::notify`
+
+Tracking interest and notifying readiness changes is done with two APIs:
+
+  * [`task::current`][current]
+  * [`Task::notify`][notify]
+
+When `my_resource.poll()` is called, if the resource is ready, it immediately
+returns the value without using the task system. If the resource is **not**
+ready, it gets a handle to the current task by calling [`task::current() ->
+Task`][current]. This handle is obtained by reading a thread-local variable set
+by the executor.
+
+Some external event (data received on the network, background thread completing
+a computation, etc...) will result in `my_resource` becoming ready to produce
+its value. At that point, the logic that readies `my_resource` will call
+[`notify`] on the task handle obtained from [`task::current`][current]. This
+signals the readiness change to the executor, which then schedules the task for
+execution.
+
+If multiple tasks have expressed interest in a resource, only the *last* task to
+have done so will be notified. Resources are intended to be used from a single
+task only.
+
+## `Async::Ready`
+
+Any function that returns `Async` must adhere to the [contract][contract]. When
+`NotReady` is returned, the current task **must** have been registered for
+notification on readiness change. The implication for resources is discussed in
+the above section. For task logic, this means that `NotReady` cannot be returned
+unless a resource has returned `NotReady`. By doing this, the
+[contract][contract] transitively upheld. The current task is registered for
+notification because `NotReady` has been received from the resource.
+
+Great care must be taken to avoiding returning `NotReady` without having
+received `NotReady` from a resource. For example, the following task
+implementation results in the task never completing.
+
+```rust
+
+enum BadTask {
+    First(Resource1),
+    Second(Resource2),
+}
+
+impl Future for BadTask {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        use self::BadTask::*;
+
+        match *self {
+            First(ref mut resource) => {
+                let value = try_ready!(resource.poll());
+                *self = Second(Resource2::new(value));
+                Ok(Async::NotReady)
+            }
+            Second(ref mut resource) => {
+                try_ready!(resource.poll());
+                Ok(Async::Ready(()))
+            }
+        }
+    }
+}
+```
+
+The problem with the above implementation is that `Ok(Async::NotReady)` is
+returned right after transitioning the state to `Second`. During this
+transition, no resource has returned `NotReady`. When the task itself returns
+`NotReady`, it has violated the [contract][contract] as the task will **not** be
+notified in the future.
+
+This situation is generally resolved by adding a loop:
+
+```rust
+fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    use self::BadTask::*;
+
+    loop {
+        match *self {
+            First(ref mut resource) => {
+                let value = try_ready!(resource.poll());
+                *self = Second(Resource2::new(value));
+            }
+            Second(ref mut resource) => {
+                try_ready!(resource.poll());
+                return Ok(Async::Ready(()));
+            }
+        }
+    }
+}
+```
+
+One way to think about it is that a task's `poll` function **must not**
+return until it is unable to make any further progress due to its resources not
+being ready or it explicitly yields (see below).
+
+Also note that **functions that return `Async` must only be called from a
+task**. In other words, these functions may only be called from code that has
+been submitted to `tokio::spawn` or other task spawn function.
+
+### Yielding
+
+Sometimes a task must return `NotReady` without being blocked on a resource.
+This usually happens when computation to run is large and the task wants to
+return control to the executor to allow it to execute other futures.
+
+Yielding is done by notifying the current task and returning `NotReady`:
+
+```rust
+task::current().notify();
+return Ok(Async::NotReady);
+```
+
+Yield can be used to break up a CPU expensive computation:
+
+```rust
+struct Count {
+    remaining: usize,
+}
+
+impl Future for Count {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        while self.remaining > 0 {
+            self.remaining -= 1;
+
+            // Yield every 10 iterations
+            if self.remaining % 10 == 0 {
+                task::current().notify();
+                return Ok(Async::NotReady);
+            }
+        }
+
+        Ok(Async::Ready(()))
+    }
+}
+```
+
+[contract]: https://docs.rs/futures/0.1.23/futures/future/trait.Future.html#tymethod.poll
+
+# Executors
+
+Executors are responsible for driving many tasks to completion. A task is
+spawned onto an executor, at which point the executor calls its `poll` function
+when needed. The executor hooks into the task system to receive resource
+readiness notifications.
+
+By decoupling the task system with the executor implementation, the specific
+execution and scheduling logic can be left to the executor implementation. Tokio
+provides two executor implementations, each with unique characteristics:
+[`current_thread`] and [`thread_pool`].
+
+When a task is first spawned onto the executor, the executor wraps it with
+[`Spawn`][Spawn]. This binds the task logic with the task state (this is mostly
+required for legacy reasons). Executors will typically store the task on the
+heap, usually by storing it in a `Box` or an `Arc`. When the executor picks a
+task for execution, it calls [`Spawn::poll_future_notify`][poll_future_notify].
+This function ensures that the task context is set to the thread-local variable
+such that [`task::current`][current] is able to read it.
+
+When calling [`poll_future_notify`][poll_future_notify], the executor also
+passes in a notify handle and an identifier. These arguments are included in the
+task handle returned by [`task::current`][current] and are how the task is
+linked to the executor.
+
+The notify handle is an implementation of [`Notify`][`Notify`] and the identifier
+is a value that the executor uses to look up the current task. When
+[`Task::notify`][notify] is called, the [`notify`][Notify::notify] function on
+the notify handle is called with the supplied identifier. The implementation of
+this function is responsible for performing the scheduling logic.
+
+One strategy for implementing an executor is to store each task in a `Box` and
+to use a linked list to track tasks that are scheduled for execution. When
+[`Notify::notify`][Notify::notify] is called, then the task associated with the
+identifier is pushed at the end of the `scheduled` linked list. When the
+executor runs, it pops from the front of the linked list and executes the task
+as described above.
+
+Note that this section does not describe how the executor is run. The details of
+this are left to the executor implementation. One option is for the executor to
+spawn one or more threads and dedicate these threads to draining the `scheduled`
+linked list. Another is to provide a `MyExecutor::run` function that blocks the
+current thread and drains the `scheduled` linked list.
+
+[`current_thread`]: #
+[`thread_pool`]: #
+[Spawn]: https://docs.rs/futures/0.1/futures/executor/struct.Spawn.html
+[poll_future_notify]: https://docs.rs/futures/0.1/futures/executor/struct.Spawn.html#method.poll_future_notify
+[current]: https://docs.rs/futures/0.1/futures/task/fn.current.html
+[notify]: https://docs.rs/futures/0.1/futures/task/struct.Task.html#method.notify
+[`Notify`]: https://docs.rs/futures/0.1/futures/executor/trait.Notify.html
+[Notify::notify]: https://docs.rs/futures/0.1/futures/executor/trait.Notify.html#tymethod.notify
+
+# Resources, drivers, and runtimes
+
+Resources are leaf futures, i.e. futures that are not implemented in terms of
+other futures. They are the types that use the task system described above to
+interact with the executor. Resource types include TCP and UDP sockets, timers,
+channels, file handles, etc. Tokio applications rarely need to implement
+resources. Instead, they use resources provided by Tokio or third party crates.
+
+Oftentimes, a resource cannot function by itself and requires a driver. For
+example, Tokio TCP sockets are backed by a [`Reactor`]. The reactor is the
+socket resource driver. A single driver may power large numbers of resource
+instances. In order to use the resource, the driver must be running somewhere in
+the process. Tokio provides drivers for network resources ([`tokio-reactor`]),
+file resources ([`tokio-fs`]), and timers ([`tokio-timer`]). Providing decoupled
+driver components allows users to pick and choose which components they wish to
+use. Each driver can be used standalone or combined with other drivers.
+
+Because of this, in order to use Tokio and successfully execute tasks, an
+application must start an executor and the necessary drivers for the resources
+that the application's tasks depend on. This requires significant boilerplate.
+To manage the boilerplate, Tokio offers a couple of runtime options. A runtime
+is an executor bundled with all necessary drivers to power Tokio's resources.
+Instead of managing all the various Tokio components individually, a runtime is
+created and started in a single call.
+
+Tokio offers a [concurrent runtime][concurrent] and a
+[single-threaded][current_thread] runtimee. The concurrent runtime is backed by
+a multi-threaded, work-stealing executor. The single-threaded runtime executes
+all tasks and drivers on thee current thread. The user may pick the runtime with
+characteristics best suited for the application.
+
+[`Reactor`]: https://docs.rs/tokio-reactor/0.1.5/tokio_reactor/
+[`tokio-reactor`]: https://docs.rs/tokio-reactor
+[`tokio-fs`]: https://docs.rs/tokio-fs
+[`tokio-timer`]: https://docs.rs/tokio-timer
+[concurrent]: https://docs.rs/tokio/0.1.8/tokio/runtime/index.html
+[current_thread]: https://docs.rs/tokio/0.1.8/tokio/runtime/current_thread/index.html
+
+# Future
+
+As mentioned above, tasks are implemented using the [`Future`] trait. This trait
+is not limited to implementing tasks. A [`Future`] is a value that represents a
+non-blocking computation that will complete sometime in the future. A task is a
+computation with no output. Many resources in Tokio are represented with
+[`Future`] implementations. For example, a timeout is a [`Future`] that
+completes once the deadline has been reached.
+
+The trait includes a number of combinators that are useful for working with
+future values.
+
+Applications are built by either implementing `Future` for application specific
+types or defining application logic using combinators. Often, a mix of both
+strategies is most successful.
+
+<!-- TODO: Expand -->
+
+[`Future`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html


### PR DESCRIPTION
A guide covering the internals. So far, this covers the runtime module and the network driver (reactor).

Examples need to pass CI still.