### PR TITLE
Small Changes to Getting-Started

### DIFF
--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -108,10 +108,6 @@ trait Future {
 }
 ```
 
-You may notice that this is the exact same trait that was used to implement an
-asynchronous task. This is because asynchronous tasks are "just" futures that
-complete with a value of `()` once the computation has completed.
-
 Usually, when you implement a `Future`, you will be defining a computation that
 is a composition of sub (or inner) futures. In this case, the future implementation tries
 to call the inner future(s) and returns `NotReady` if the inner futures are not
@@ -183,13 +179,12 @@ fn poll(&mut self) -> Result<Async<usize>, T::Error> {
 
 # Returning `NotReady`
 
-The last section handwaved a bit and said that when a task returns `NotReady`,
-once it transitioned to the ready state, the executor is notifed. This enables
-the executor to be efficient in scheduling tasks.
+The last section handwaved a bit and said that once a Future transitioned to the
+ready state, the executor is notifed. This enables the executor to be efficient
+in scheduling tasks.
 
-When a function returns `Async::NotReady`, it is critical that the executor is
-notified when the state transitions to "ready". Otherwise, the task will hang
-infinitely, never getting run again.
+It is critical that the executor is notified when the state transitions to "ready".
+Otherwise, the task will hang infinitely, never getting run again.
 
 For most future implementations, this is done transitively. When a future
 implementation is a combination of sub futures, the outer future only returns
@@ -202,18 +197,13 @@ Innermost futures, sometimes called "resources", are the ones responsible for
 notifying the executor. This is done by calling [`notify`] on the task returned
 by [`task::current()`].
 
-Before an executor calls `poll` on a task, it sets the task context to a
-thread-local variable. The inner most future then accesses the context from the
-thread-local so that it is able to notify the task once its readiness state
-changes.
-
 We will be exploring implementing resources and the task system in more depth in
 a later section. The key take away here is **do not return `NotReady` unless you
 got `NotReady` from an inner future**.
 
 # A More Complicated Future
 
-Lets look at a slightly more complicated future implementation. In this case, we
+Let's look at a slightly more complicated future implementation. In this case, we
 will implement a future that takes a host name, does DNS resolution, then
 establishes a connection to the remote host. We assume a `resolve` function
 exists that looks like this:
@@ -307,6 +297,8 @@ impl Future for ResolveAndConnect {
                 }
             };
 
+            // If we reach here, the state was `Resolving`
+            // and the call to the inner Future returned `Ready`
             let connecting = TcpStream::connect(&addr);
             self.state = Connecting(connecting);
         }
@@ -324,8 +316,8 @@ can be in either of two states:
 Each time `poll` is called, we try to advance the state machine to the next
 state.
 
-Now, the future we just implemented is basically [`AndThen`], so we would
-probably just use that combinator instead of re-implementing it.
+Now, the future is basically a re-implementation of the combinator [`AndThen`], so we would
+probably just use that combinator.
 
 ```rust
 # #![deny(deprecated)]
@@ -353,7 +345,7 @@ resolve(my_host)
 # pub fn main() {}
 ```
 
-which is much shorter.
+This is much shorter and does the same thing.
 
 [`futures`]: {{< api-url "futures" >}}
 [`notify`]: {{< api-url "futures" >}}/executor/trait.Notify.html#tymethod.notify

--- a/content/docs/getting-started/runtime-model.md
+++ b/content/docs/getting-started/runtime-model.md
@@ -93,6 +93,7 @@ To define a task, we implement the [`Future`] trait.
 pub struct MyTask;
 
 impl Future for MyTask {
+    // The value this future will have when ready
     type Item = ();
     type Error = ();
 
@@ -103,7 +104,7 @@ impl Future for MyTask {
                 Ok(Async::Ready(()))
             }
             Async::NotReady => {
-                return Ok(Async::NotReady);
+                Ok(Async::NotReady)
             }
         }
     }
@@ -148,6 +149,8 @@ At the very simplest, an executor could look something like this:
 # use std::collections::VecDeque;
 #
 pub struct SpinExecutor {
+    // the tasks an executor is responsbile for in
+    // a double ended queue
     tasks: VecDeque<Box<Future<Item = (), Error = ()>>>,
 }
 


### PR DESCRIPTION
These are small changes to the getting started guide. Mostly I removed information that in my opinion came too early and just made things more confusing. 

Besides these changes I have some thoughts/suggestions:
* It would be better to introduce Futures and Tasks purely through combinators and only once the reader has a good understanding of that, introduce writing custom Futures. 
* Now that `impl Trait` is stable, it might make sense to use that syntax everywhere and just make a short mention that if the reader wants to use an older version of Rust, they should look at the "Returning Futures" guide.
* `ErrorKind::WouldBlock` is mentioned a few times, but the underlying mechanism for resources to go from `NotReady` to `Ready`, I wonder if hand waving and never even mentioning `WouldBlock` would be less confusing.