### PR TITLE
Change how and when ErrorKind::WouldBlock is mentioned

### DIFF
--- a/content/docs/getting-started/io.md
+++ b/content/docs/getting-started/io.md
@@ -39,9 +39,9 @@ mandated properties:
 
 * Calls to `read` or `write` are **nonblocking**, they never block the calling
   thread.
-* If a call would otherwise block then an error is returned with the kind of
-  `WouldBlock`. If this happens then the current future's task is scheduled to
-  receive a notification (an unpark) when the I/O is ready again.
+* If a call would otherwise block then the function returns a value indicating so.
+  If this happens then the current future's task is scheduled to receive a
+  notification (known as an 'unpark') when the I/O is ready again.
 
 Note that users of [`AsyncRead`] and [`AsyncWrite`] types should use
 [`poll_read`] and [`poll_write`] instead of directly calling [`read`] and [`write`].

--- a/content/docs/getting-started/runtime-model.md
+++ b/content/docs/getting-started/runtime-model.md
@@ -49,10 +49,10 @@ not block the thread! When the socket has no pending data in its receive buffer,
 the `read` function returns immediately, indicating that the socket was "not
 ready" to perform the read operation.
 
-When using a Tokio [`TcpStream`], a call to `read` will return an error of kind
-[`ErrorKind::WouldBlock`] if there is no pending data to read. At this point,
-the caller is responsible for calling `read` again at a later time. The trick is
-to know when that "later time" is.
+When using a Tokio [`TcpStream`], a call to `read` will always immediately return
+a value ([`ErrorKind::WouldBlock`]) even if there is no pending data to read.
+If there is no pending data, the caller is responsible for calling `read` again
+at a later time.  The trick is to know when that "later time" is.
 
 Another way to think about a non-blocking read is as "polling" the socket for
 data to read.


### PR DESCRIPTION
In general `ErrorKind::WouldBlock` is an implementation detail and not super relevant to the topic at hand. It was mentioned twice, once of which I completely removed. The other mention I still left in, but de-emphasized it by moving it into parentheses. 