### PR TITLE
Fix broken link to async/await with Hyper.

### DIFF
--- a/content/blog/2018-08-async-await.md
+++ b/content/blog/2018-08-async-await.md
@@ -169,4 +169,4 @@ And with that, have a great week!
 
 [`tokio-async-await`]: https://crates.io/crates/tokio-async-await
 [examples]: https://github.com/tokio-rs/tokio/blob/master/tokio-async-await/examples
-[hyper]: https://github.com/tokio-rs/tokio/blob/master/tokio-async-await/examples/hyper.rs
+[hyper]: https://github.com/tokio-rs/tokio/blob/master/tokio-async-await/examples/src/hyper.rs

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -111,7 +111,7 @@ dropped. At this point, the computation will no longer be polled and thus
 perform no more work.
 
 Thanks to Rust's ownership model, the computation is able to implement `drop`
-handles to detect the future being droped. This allows it to perform any
+handles to detect the future being dropped. This allows it to perform any
 necessary cleanup work.
 
 # Lightweight


### PR DESCRIPTION
The link to the Hyper example with async/await was broken. This PR corrects that.