### PR TITLE
Change get started link

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
           ensure thread safety.
         </p>
         <div class="d-flex flex-column flex-md-row lead mb-3">
-          <a href="{{ ref . "/docs/getting-started/hello-world.md" }}" class="btn btn-lg btn-tk-primary mb-3 mb-md-0 mr-md-3">Get started</a>
+          <a href="{{ ref . "/docs/overview.md" }}" class="btn btn-lg btn-tk-primary mb-3 mb-md-0 mr-md-3">Get started</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The overview page is very easy to miss, and I think users are better off landing there before moving on to hello-world. 