### PR TITLE
Simplify the hello world Example

### DIFF
--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -7,10 +7,14 @@ menu:
 ---
 
 To kick off our tour of Tokio, we will start with the obligatory "hello world"
-example. This program will create a file and write "hello, world!" to the file.
-The difference between this and a Rust program that writes to a file without Tokio
-is that this program won't block program execution when the file is created or when
-our "hello, world!" message is written to the file.
+example. This program will create a TCP stream and write "hello, world!" to the stream.
+The difference between this and a Rust program that writes to a TCP stream without Tokio
+is that this program won't block program execution when the stream is created or when
+our "hello, world!" message is written to the stream.
+
+Before we begin you should have a very basic understanding of how TCP streams work. Having
+an understanding of Rust’s [standard library implementation](https://doc.rust-lang.org/std/net/struct.TcpStream.html)
+is also helpful.
 
 Let's get started.
 
@@ -35,42 +39,45 @@ and the crates and types into scope in `main.rs`:
 extern crate tokio;
 
 use tokio::io;
-use tokio::fs::File;
+use tokio::net::TcpStream;
 use tokio::prelude::*;
 # fn main() {}
 ```
 
-# Creating the file
+# Creating the stream
 
-The first step is to create the `File`. We use the `File` implementation provided by Tokio.
+The first step is to create the `TcpStream`. We use the `TcpStream` implementation provided
+by Tokio.
 
 ```rust
 # #![deny(deprecated)]
 # extern crate tokio;
 #
-# use tokio::fs::File;
+# use tokio::net::TcpStream;
 fn main() {
-    let file = File::create("hello.txt");
+    // Parse the address of whatever server we're talking to
+    let addr = "127.0.0.1:6142".parse().unwrap();
+    let stream = TcpStream::connect(&addr);
 
     // Following snippets come here...
 }
 ```
 
-Next, we define the `hello_world` task. This asynchronous task will create the file
-and then yield the file once it's been created for additional processing.
+Next, we define the `client` task. This asynchronous task will create the stream
+and then yield the stream once it's been created for additional processing.
 
 ```rust
 # #![deny(deprecated)]
 # extern crate tokio;
 #
-# use tokio::io;
-# use tokio::fs::File;
+# use tokio::net::TcpStream;
 # use tokio::prelude::*;
 # fn main() {
-let hello_world = File::create("hello.txt").and_then(|file| {
-    println!("created file");
+# let addr = "127.0.0.1:6142".parse().unwrap();
+let hello_world = TcpStream::connect(&addr).and_then(|stream| {
+    println!("created stream");
 
-    // Process file here.
+    // Process stream here.
 
     Ok(())
 })
@@ -79,20 +86,20 @@ let hello_world = File::create("hello.txt").and_then(|file| {
     // handling and helps avoid silencing failures.
     //
     // In our example, we are only going to log the error to STDOUT.
-    println!("creation error = {:?}", err);
+    println!("connection error = {:?}", err);
 });
 # }
 ```
 
-The call to `File::create` returns a [`Future`] of the created file.
+The call to `TcpStream::connect` returns a [`Future`] of the created TCP stream.
 We'll learn more about [`Futures`] later in the guide, but for now you can think of
 a [`Future`] as a value that represents something that will eventually happen in the
-future (in this case the file will be created). This means that `File::create` does
-not wait for the file to be created before it returns. Rather it returns immediately
-with a value representing the work of creating a file. We'll see down below when this work
+future (in this case the stream will be created). This means that `TcpStream::connect` does
+not wait for the stream to be created before it returns. Rather it returns immediately
+with a value representing the work of creating a TCP stream. We'll see down below when this work
 _actually_ gets executed.
 
-The `and_then` method yields the file once it has been created. `and_then` is an
+The `and_then` method yields the stream once it has been created. `and_then` is an
 example of a combinator function that defines how asynchronous work will be processed.
 
 Each combinator function takes ownership of necessary state as well as the
@@ -104,7 +111,7 @@ It's worth reiterating that returned futures are lazy, i.e., no work is performe
 calling the combinator. Instead, once all the asynchronous steps are sequenced, the
 final `Future` (representing the entire task) is "spawned" (i.e., run). This is when
 the work that was previously defined starts getting run. In other words, the code
-we've written so far does not actually create a file.
+we've written so far does not actually create a TCP stream.
 
 We will be digging more into futures (and the related concepts of streams and sinks)
 later on.
@@ -113,13 +120,13 @@ It's also important to note that we've called `map_err` to convert whatever erro
 we may have gotten to `()` before we can actually run our future. This ensures that
 we acknowledge errors.
 
-Next, we will process the file.
+Next, we will process the stream.
 
 # Writing data
 
-Our goal is to write `"hello world\n"` to the file.
+Our goal is to write `"hello world\n"` to the stream.
 
-Going back to the `File::create().and_then` block:
+Going back to the `TcpStream::connect(addr).and_then` block:
 
 ```rust
 # #![deny(deprecated)]
@@ -127,13 +134,14 @@ Going back to the `File::create().and_then` block:
 #
 # use tokio::io;
 # use tokio::prelude::*;
-# use tokio::fs::File;
+# use tokio::net::TcpStream;
 # fn main() {
-let hello_world = File::create("hello.txt").and_then(|file| {
-    println!("created file");
+# let addr = "127.0.0.1:6142".parse().unwrap();
+let client = TcpStream::connect(&addr).and_then(|stream| {
+    println!("created stream");
 
-    io::write_all(file, "hello world\n").then(|result| {
-      println!("wrote to file; success={:?}", result.is_ok());
+    io::write_all(stream, "hello world\n").then(|result| {
+      println!("wrote to stream; success={:?}", result.is_ok());
       Ok(())
     })
 })
@@ -141,17 +149,17 @@ let hello_world = File::create("hello.txt").and_then(|file| {
 # }
 ```
 
-The [`io::write_all`] function takes ownership of `file`, returning a
+The [`io::write_all`] function takes ownership of `stream`, returning a
 [`Future`] that completes once the entire message has been written to the
-file. `then` is used to sequence a step that gets run once the write has
+stream. `then` is used to sequence a step that gets run once the write has
 completed. In our example, we just write a message to `STDOUT` indicating that
 the write has completed.
 
-Note that `result` is a `Result` that contains the original file. This allows us
-to sequence additional reads or writes to the same file. However, we have
-nothing more to do, so we just drop the file, which automatically closes it.
+Note that `result` is a `Result` that contains the original stream. This allows us
+to sequence additional reads or writes to the same stream. However, we have
+nothing more to do, so we just drop the stream, which automatically closes it.
 
-# Running the hello_world task
+# Running the client task
 
 So far we have a `Future` representing the work to be done by our program, but we
 have not actually run it. We need a way to "spawn" that work. We need an executor.
@@ -169,18 +177,17 @@ different pros and cons. In this example, we will use the default executor of th
 # use tokio::prelude::*;
 # use futures::future;
 # fn main() {
-# let hello_world = future::ok(());
-
-println!("About to create the file...");
-tokio::run(hello_world);
-println!("File has been created.");
+# let client = future::ok(());
+println!("About to create the stream and write to it...");
+tokio::run(client);
+println!("Stream has been created and written to.");
 # }
 ```
 
 `tokio::run` starts the runtime, blocking the current thread until all spawned tasks
-have completed and all resources (like files) have been dropped.
+have completed and all resources (like files and sockets) have been dropped.
 
-So far, we only have a single task running on the executor, so the `hello_world` task
+So far, we only have a single task running on the executor, so the `client` task
 is the only one blocking `run` from returning. Once `run` has returned we can be sure
 that our Future has been run to completion.
 

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -7,12 +7,10 @@ menu:
 ---
 
 To kick off our tour of Tokio, we will start with the obligatory "hello world"
-example. This server will listen for incoming connections. Once a connection is
-received, it will write "hello world" to the client and close the connection.
-
-Before we begin you should have a basic understanding of how TCP sockets work. Having
-an understanding of Rust's [standard library implementation][TcpListener] is also
-helpful.
+example. This program will create a file and write "hello, world!" to the file.
+The difference between this and a Rust program that writes to a file without Tokio
+is that this program won't block program execution when the file is created or when
+our "hello, world!" message is written to the file.
 
 Let's get started.
 
@@ -37,48 +35,42 @@ and the crates and types into scope in `main.rs`:
 extern crate tokio;
 
 use tokio::io;
-use tokio::net::TcpListener;
+use tokio::fs::File;
 use tokio::prelude::*;
 # fn main() {}
 ```
 
-# Writing the server
+# Creating the file
 
-The first step is to bind a `TcpListener` to a local port. We use the
-`TcpListener` implementation provided by Tokio.
+The first step is to create the `File`. We use the `File` implementation provided by Tokio.
 
 ```rust
 # #![deny(deprecated)]
 # extern crate tokio;
 #
-# use tokio::io;
-# use tokio::net::TcpListener;
-# use tokio::prelude::*;
+# use tokio::fs::File;
 fn main() {
-    let addr = "127.0.0.1:6142".parse().unwrap();
-    let listener = TcpListener::bind(&addr).unwrap();
+    let file = File::create("hello.txt");
 
     // Following snippets come here...
 }
 ```
 
-Next, we define the server task. This asynchronous task will listen for incoming
-connections on the bound listener and process each accepted connection.
+Next, we define the `hello_world` task. This asynchronous task will create the file
+and then yield the file once it's been created for additional processing.
 
 ```rust
 # #![deny(deprecated)]
 # extern crate tokio;
 #
 # use tokio::io;
-# use tokio::net::TcpListener;
+# use tokio::fs::File;
 # use tokio::prelude::*;
 # fn main() {
-#     let addr = "127.0.0.1:0".parse().unwrap();
-#     let listener = TcpListener::bind(&addr).unwrap();
-let server = listener.incoming().for_each(|socket| {
-    println!("accepted socket; addr={:?}", socket.peer_addr().unwrap());
+let hello_world = File::create("hello.txt").and_then(|file| {
+    println!("created file");
 
-    // Process socket here.
+    // Process file here.
 
     Ok(())
 })
@@ -87,122 +79,109 @@ let server = listener.incoming().for_each(|socket| {
     // handling and helps avoid silencing failures.
     //
     // In our example, we are only going to log the error to STDOUT.
-    println!("accept error = {:?}", err);
+    println!("creation error = {:?}", err);
 });
 # }
 ```
 
-The call to `listener.incoming()` returns a [`Stream`] of accepted connections.
-We'll learn more about [`Streams`] later in the guide, but for now you can think of
-a [`Stream`] as an asynchronous iterator. The `for_each` method yields new sockets
-each time a socket is accepted. `for_each` is an example of a combinator function that
-defines how asynchronous work will be processed.
+The call to `File::create` returns a [`Future`] of the created file.
+We'll learn more about [`Futures`] later in the guide, but for now you can think of
+a [`Future`] as a value that represents something that will eventually happen in the
+future (in this case the file will be created). This means that `File::create` does
+not wait for the file to be created before it returns. Rather it returns immediately
+with a value representing the work of creating a file. We'll see down below when this work
+_actually_ gets executed.
+
+The `and_then` method yields the file once it has been created. `and_then` is an
+example of a combinator function that defines how asynchronous work will be processed.
 
 Each combinator function takes ownership of necessary state as well as the
-callback to perform and returns a new `Stream` or a `Future` that has the
-additional "step" sequenced. A `Future` is a value representing some computation
-that will complete at some point in the future
+callback to perform and returns a new `Future` that has the additional "step"
+sequenced. A `Future` is a value representing some computation that will complete at
+some point in the future
 
-Returned futures and streams are lazy, i.e., no work is performed when calling
-the combinator. Instead, once all the asynchronous steps are sequenced, the
+It's worth reiterating that returned futures are lazy, i.e., no work is performed when
+calling the combinator. Instead, once all the asynchronous steps are sequenced, the
 final `Future` (representing the entire task) is "spawned" (i.e., run). This is when
-the work that was previously defined starts getting run.
+the work that was previously defined starts getting run. In other words, the code
+we've written so far does not actually create a file.
 
-We will be digging into futures and streams later on.
+We will be digging more into futures (and the related concepts of streams and sinks)
+later on.
 
-# Running the server
+It's also important to note that we've called `map_err` to convert whatever error
+we may have gotten to `()` before we can actually run our future. This ensures that
+we acknowledge errors.
 
-So far we have a `Future` representing the work to be done by our server, but we
-need a way to spawn that work. We need an executor.
+Next, we will process the file.
+
+# Writing data
+
+Our goal is to write `"hello world\n"` to the file.
+
+Going back to the `File::create().and_then` block:
+
+```rust
+# #![deny(deprecated)]
+# extern crate tokio;
+#
+# use tokio::io;
+# use tokio::fs::File;
+# fn main() {
+let hello_world = File::create("hello.txt").and_then(|file| {
+    println!("created file");
+
+    io::write_all(file, "hello world\n").then(|result| {
+      println!("wrote to file; success={:?}", result.is_ok());
+      Ok(())
+    });
+})
+# ;
+# }
+```
+
+The [`io::write_all`] function takes ownership of `file`, returning a
+[`Future`] that completes once the entire message has been written to the
+file. `then` is used to sequence a step that gets run once the write has
+completed. In our example, we just write a message to `STDOUT` indicating that
+the write has completed.
+
+Note that `result` is a `Result` that contains the original file. This allows us
+to sequence additional reads or writes to the same file. However, we have
+nothing more to do, so we just drop the file, which automatically closes it.
+
+# Running the hello_world task
+
+So far we have a `Future` representing the work to be done by our program, but we
+have not actually run it. We need a way to "spawn" that work. We need an executor.
 
 Executors are responsible for scheduling asynchronous tasks, driving them to
 completion. There are a number of executor implementations to choose from, each have
-different pros and cons. In this example, we will use the [Tokio runtime][rt]
-which comes with a set executor implementation.
-
-The Tokio runtime is a pre-configured runtime for asynchronous applications. It
-includes a thread pool as the default executor. This thread pool is tuned for
-usage in asynchronous applications.
+different pros and cons. In this example, we will use the default executor of the
+[Tokio runtime][rt].
 
 ```rust
 # #![deny(deprecated)]
 # extern crate tokio;
 # extern crate futures;
 #
-# use tokio::io;
-# use tokio::net::TcpListener;
 # use tokio::prelude::*;
 # use futures::future;
 # fn main() {
-# let server = future::ok(());
+# let hello_world = future::ok(());
 
-println!("server running on localhost:6142");
-tokio::run(server);
+println!("About to create the file...");
+tokio::run(hello_world);
+println!("File has been created.");
 # }
 ```
 
-`tokio::run` starts the runtime, blocking the current thread until
-all spawned tasks have completed and all resources (like TCP sockets) have been
-dropped.
+`tokio::run` starts the runtime, blocking the current thread until all spawned tasks
+have completed and all resources (like files) have been dropped.
 
-So far, we only have a single task running on the executor, so the `server` task
-is the only one blocking `run` from returning.
-
-Next, we will process the inbound sockets.
-
-# Writing Data
-
-Our goal is to write `"hello world\n"` on each accepted socket. We will do this
-by defining a new asynchronous task to do the write and spawning that task on
-the same executor.
-
-Going back to the `incoming().for_each` block:
-
-```rust
-# #![deny(deprecated)]
-# extern crate tokio;
-#
-# use tokio::io;
-# use tokio::net::TcpListener;
-# use tokio::prelude::*;
-# fn main() {
-#     let addr = "127.0.0.1:0".parse().unwrap();
-#     let listener = TcpListener::bind(&addr).unwrap();
-let server = listener.incoming().for_each(|socket| {
-    println!("accepted socket; addr={:?}", socket.peer_addr().unwrap());
-
-    let connection = io::write_all(socket, "hello world\n")
-        .then(|res| {
-            println!("wrote message; success={:?}", res.is_ok());
-            Ok(())
-        });
-
-    // Spawn a new task that processes the socket:
-    tokio::spawn(connection);
-
-    Ok(())
-})
-# ;
-# }
-```
-
-We are defining another asynchronous task. This task will take ownership of the
-socket, write the message on that socket, then complete. The `connection`
-variable holds the final task. Again, no work has yet been performed.
-
-`tokio::spawn` is used to spawn the task on the runtime. Because the
-`server` future is running on the runtime, we are able to spawn further tasks.
-`tokio::spawn` will panic if called from outside of the runtime.
-
-The [`io::write_all`] function takes ownership of `socket`, returning a
-[`Future`] that completes once the entire message has been written to the
-socket. `then` is used to sequence a step that gets run once the write has
-completed. In our example, we just write a message to `STDOUT` indicating that
-the write has completed.
-
-Note that `res` is a `Result` that contains the original socket. This allows us
-to sequence additional reads or writes on the same socket. However, we have
-nothing more to do, so we just drop the socket, which closes it.
+So far, we only have a single task running on the executor, so the `hello_world` task
+is the only one blocking `run` from returning. Once `run` has returned we can be sure
+that our Future has been run to completion.
 
 You can find the full example [here][full-code].
 
@@ -211,10 +190,7 @@ You can find the full example [here][full-code].
 We've only dipped our toes into Tokio and its asynchronous model. The next page in
 the guide, will start digging deeper into the Tokio runtime model.
 
-[TcpListener]:https://doc.rust-lang.org/std/net/struct.TcpListener.html
 [`Future`]: {{< api-url "futures" >}}/future/trait.Future.html
-[`Stream`]: {{< api-url "futures" >}}/stream/trait.Stream.html
 [rt]: {{< api-url "tokio" >}}/runtime/index.html
 [`io::write_all`]: {{< api-url "tokio-io" >}}/io/fn.write_all.html
-[`tokio::spawn`]: {{< api-url "tokio" >}}/fn.spawn.html
 [full-code]:https://github.com/tokio-rs/tokio/blob/master/examples/hello_world.rs

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -126,6 +126,7 @@ Going back to the `File::create().and_then` block:
 # extern crate tokio;
 #
 # use tokio::io;
+# use tokio::prelude::*;
 # use tokio::fs::File;
 # fn main() {
 let hello_world = File::create("hello.txt").and_then(|file| {
@@ -134,7 +135,7 @@ let hello_world = File::create("hello.txt").and_then(|file| {
     io::write_all(file, "hello world\n").then(|result| {
       println!("wrote to file; success={:?}", result.is_ok());
       Ok(())
-    });
+    })
 })
 # ;
 # }


### PR DESCRIPTION
The current hello-world example is fairly complex. It uses Streams and Futures, and it spawns sub-tasks on the runtime from within a combinator. It also uses sockets which might require a bit more background knowledge than files do. I think ultimately the "example" page of the getting started section should be as complex as the current hello-world example. 

The hello world example is now truely minimal. It has two futures and it spawns the parent future on the runtime. It deals with files which everyone should be familiar with. 