### PR TITLE
IO Overview WIP

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,7 @@ params:
   tokioDocsURL: "https://docs.rs/tokio/0.1/tokio"
   tokioExecutorDocsURL: "https://docs.rs/tokio-executor/0.1/tokio_executor"
   tokioIoDocsURL: "https://docs.rs/tokio-io/0.1/tokio_io"
+  tokioReactorDocsURL: "https://tokio-rs.github.io/tokio/tokio_reactor/"
   tokioTimerDocsURL: "https://docs.rs/tokio-timer/0.2"
   futuresDocsURL: "https://docs.rs/futures/0.1/futures"
   coreDocsURL: "https://docs.rs/tokio-core/0.1/tokio_core"

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,7 @@ params:
   tokioReactorDocsURL: "https://tokio-rs.github.io/tokio/tokio_reactor/"
   tokioTimerDocsURL: "https://docs.rs/tokio-timer/0.2"
   futuresDocsURL: "https://docs.rs/futures/0.1/futures"
+  mioDocsURL: "https://docs.rs/mio/*/mio"
   coreDocsURL: "https://docs.rs/tokio-core/0.1/tokio_core"
   protoDocsURL: "https://tokio-rs.github.io/tokio-proto/tokio_proto"
   serviceDocsURL: "https://tokio-rs.github.io/tokio-service/tokio_service"

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -53,13 +53,29 @@ the buffer, and reevaluating `.incoming()`.
 allow an event loop to respond to I/O rather than wait for it.  That event loop
 is [`Tokio::reactor`] which receives events from [`mio`].
 
+[`mio::net`] implements networking primitives that allow polling events.
+[`mio::unix`] implement UNIX inter-process communication channels with polling.
+
+## Included with Tokio
+
+Tokio provides the high level interfaces to asynchronous IO for
+
+  * [`TCP sockets`]
+  * [`UDP sockets`]
+  * [`Unix sockets`]
+
 
 [`AsyncRead`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html
 [`AsyncWrite`]: {{< api-url "tokio" >}}/io/trait.AsyncWrite.html
 [`futures::Async`]: {{< api-url "futures" >}}/enum.Async.html
-[`mio`]: https://docs.rs/mio/*/mio/
+[`mio`]: {{< api-url "mio" >}}
+[`mio::net`]: {{< api-url "mio" >}}/net/index.html
+[`mio::unix`]: {{< api-url "mio" >}}/unix/index.html
 [`std::fs`]: https://doc.rust-lang.org/std/fs/struct.File.html#implementations
 [`std::io`]: https://doc.rust-lang.org/std/io/#read-and-write
 [`std::net` examples]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#examples
+[`TCP sockets`]: {{< api-url "tokio" >}}/net/tcp/index.html
 [`tokio`]: {{< api-url "tokio" >}}
 [`Tokio::reactor`]: {{< api-url "tokio-reactor" >}}
+[`UDP sockets`]: {{< api-url "tokio" >}}/net/udp/index.html
+[`Unix sockets`]: {{< api-url "tokio" >}}/net/unix/index.html

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -15,9 +15,44 @@ The [`tokio`] crate comes with a variation on those types, [`AsyncRead`] and
 is the [`futures::Async`] return values.  The implementation returns an `Error`,
 `NotReady`, or `Ready` value.
 
+## Non Blocking
+
+The nature of a polling data reader/writer allows for other tasks to operate
+before data reaches the socket or disk queue.  Synchronous operations evaluate
+in a guaranteed sequential manner, and require commands to complete before the
+next operation executes.
+
+Consider this `std::net` implementation from the [`std::net` examples]
+
+```rust,no_run
+# #![allow(unused)]
+# use std::io;
+use std::net::{TcpListener, TcpStream};
+
+# fn handle_client(stream: TcpStream) {
+#     // ...
+# }
+#
+fn main() -> io::Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:8000")?;
+#
+#     // accept connections and process them serially
+    for stream in listener.incoming() {
+        handle_client(stream?);
+    }
+#    Ok(())
+}
+```
+
+This single-threaded process will evaluate through calling `.incoming()` on
+the `TcpListener` and will continue to run until receiving a KILL signal from
+the operating system or until enough data is received on the TCP port to flush
+the buffer.
+
 [`AsyncRead`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html
 [`AsyncWrite`]: {{< api-url "tokio" >}}/io/trait.AsyncWrite.html
 [`futures::Async`]: https://docs.rs/futures/0.1.18/futures/enum.Async.html
 [`std::io`]: https://doc.rust-lang.org/std/io/#read-and-write
 [`std::fs`]: https://doc.rust-lang.org/std/fs/struct.File.html#implementations
+[`std::net` examples]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#examples
 [`tokio`]: {{< api-url "tokio" >}}

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -50,15 +50,42 @@ the operating system or until enough data is received on the TCP port to flush
 the buffer, and reevaluating `.incoming()`.
 
 `Tokio` I/O, rather than pausing execution, uses a `Futures` based syntax to
-allow an event loop to respond to I/O rather than wait for it.  That event loop
-is [`Tokio::reactor`] which receives events from [`mio`].
+allow an event loop to respond to I/O rather than wait for it.  For network I/O
+the driver is [`Tokio::reactor`] which receives events from [`mio`].
+
+### Mio
+
+Mio is a [cross platform] implementation of low-level I/O.  Mio's goal is to
+create a unified syntax to operate on a wide range of platforms.  This makes
+Tokio applications portable by default.
+
+#### Evented
+
+Mio includes a trait [`Evented`] which designates a source of `Event`.  The
+implementation of the trait [`register`]s with [`Poll`].  To receive an `Event`,
+the executor will `poll` the registered `Evented` value and forward it to the
+pending future task.
+
+#### Polling
+
+Mio's [`Poll::poll`] call is a synchronous call that blocks execution of the
+thread for a given `Duration`.  This call may generate multiple [`Events`]
+which are processed followed by another call to `Poll::poll`.
+
+#### Primitives
 
 [`mio::net`] implements networking primitives that allow polling events.
 [`mio::unix`] implement UNIX inter-process communication channels with polling.
 
+### Tokio Runtime
+
+`mio` does not provide scheduling.  Tokio shines by using configuration to
+implement a `Runtime Model` that matches the properties of a specific resource.
+
+
 ## Included with Tokio
 
-Tokio provides the high level interfaces to asynchronous IO for
+Tokio provides the high level interfaces to asynchronous I/O for
 
   * [`TCP sockets`]
   * [`UDP sockets`]
@@ -67,10 +94,15 @@ Tokio provides the high level interfaces to asynchronous IO for
 
 [`AsyncRead`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html
 [`AsyncWrite`]: {{< api-url "tokio" >}}/io/trait.AsyncWrite.html
+[`Evented`]: {{< api-url "mio" >}}/event/trait.Evented.html
+[`Events`]: {{< api-url "mio" >}}/struct.Events.html
 [`futures::Async`]: {{< api-url "futures" >}}/enum.Async.html
 [`mio`]: {{< api-url "mio" >}}
 [`mio::net`]: {{< api-url "mio" >}}/net/index.html
 [`mio::unix`]: {{< api-url "mio" >}}/unix/index.html
+[`Poll`]: {{< api-url "mio" >}}/struct.Poll.html
+[`Poll::poll`]: {{< api-url "mio" >}}/struct.Poll.html#method.poll
+[`register`]: {{< api-url "mio" >}}/struct.Poll.html#method.register
 [`std::fs`]: https://doc.rust-lang.org/std/fs/struct.File.html#implementations
 [`std::io`]: https://doc.rust-lang.org/std/io/#read-and-write
 [`std::net` examples]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#examples
@@ -79,3 +111,4 @@ Tokio provides the high level interfaces to asynchronous IO for
 [`Tokio::reactor`]: {{< api-url "tokio-reactor" >}}
 [`UDP sockets`]: {{< api-url "tokio" >}}/net/udp/index.html
 [`Unix sockets`]: {{< api-url "tokio" >}}/net/unix/index.html
+[cross platform]: {{< api-url "mio" >}}/#platforms

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -6,21 +6,23 @@ menu:
     parent: io
 ---
 
-Rust [`std::io`] module provides traits that synchronously access resources like
-files and sockets.  These `Read` and `Write` traits are implemented in other
-modules including [`std::fs`] and `std::net`.
+Rust provides types, traits, and helpers for performing synchronous I/O
+operations, such as working with TCP, UDP, and, reading from and writing to
+files.
 
-The [`tokio`] crate comes with a variation on those types, [`AsyncRead`] and
-[`AsyncWrite`].  The primary difference between [`AsyncRead`] and `std::io::Read`
-is the [`futures::Async`] return values.  The implementation returns an `Error`,
-`NotReady`, or `Ready` value.
+The [`tokio`] crate improves on those operations by providing non-blocking
+versions.  Tokio provides the high level interfaces to asynchronous I/O for
 
-## Non Blocking
+* [TCP sockets]
+* [UDP sockets]
+* [Unix sockets]
+* [File operations]
 
-The nature of a polling data reader/writer allows for other tasks to operate
-before data reaches the socket or disk queue.  Synchronous operations evaluate
-in a guaranteed sequential manner, and require commands to complete before the
-next operation executes.
+## Blocking vs Non-Blocking
+
+Synchronous operations evaluate in a guaranteed sequential manner, and require
+expressions to complete before the next operation executes.  This is the
+default behavior in Rust.  
 
 Consider this `std::net` implementation from the [`std::net` examples]
 
@@ -47,68 +49,26 @@ fn main() -> io::Result<()> {
 This single-threaded process will evaluate through calling `.incoming()` on
 the `TcpListener` and will continue to run until receiving a KILL signal from
 the operating system or until enough data is received on the TCP port to flush
-the buffer, and reevaluating `.incoming()`.
+the buffer then reevaluates `.incoming()`.
 
-`Tokio` I/O, rather than pausing execution, uses a `Futures` based syntax to
-allow an event loop to respond to I/O rather than wait for it.  For network I/O
-the driver is [`Tokio::reactor`] which receives events from [`mio`].
+Asynchronous I/O provides a method to register a task to execute when the
+program receives data.   
 
-### Mio
+`Tokio`, rather than pausing execution, uses a `Futures` based syntax allowing
+tasks to respond to I/O events as they arrive rather than wait for them
+Networking events are provided by [`mio`], a non-blocking I/O library backed by
+the operating system's event queue.  Filesystem I/O is implemented in
+[`Tokio::fs`].
 
-Mio is a [cross platform] implementation of low-level I/O.  Mio's goal is to
-create a unified syntax to operate on a wide range of platforms.  This makes
-Tokio applications portable by default.
+A `tokio` equivalent to the `std::net` implementation above would register a
+future on the `TcpListener` (provided by [tokio::net::tcp]).
 
-#### Evented
-
-Mio includes a trait [`Evented`] which designates a source of `Event`.  The
-implementation of the trait [`register`]s with [`Poll`].  To receive an `Event`,
-the executor will `poll` the registered `Evented` value and forward it to the
-pending future task.
-
-#### Polling
-
-Mio's [`Poll::poll`] call is a synchronous call that blocks execution of the
-thread for a given `Duration`.  This call may generate multiple [`Events`]
-which are processed followed by another call to `Poll::poll`.
-
-#### Primitives
-
-[`mio::net`] implements networking primitives that allow polling events.
-[`mio::unix`] implement UNIX inter-process communication channels with polling.
-
-### Tokio Runtime
-
-`mio` does not provide scheduling.  Tokio shines by using configuration to
-implement a `Runtime Model` that matches the properties of a specific resource.
-
-
-## Included with Tokio
-
-Tokio provides the high level interfaces to asynchronous I/O for
-
-  * [`TCP sockets`]
-  * [`UDP sockets`]
-  * [`Unix sockets`]
-
-
-[`AsyncRead`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html
-[`AsyncWrite`]: {{< api-url "tokio" >}}/io/trait.AsyncWrite.html
-[`Evented`]: {{< api-url "mio" >}}/event/trait.Evented.html
-[`Events`]: {{< api-url "mio" >}}/struct.Events.html
-[`futures::Async`]: {{< api-url "futures" >}}/enum.Async.html
 [`mio`]: {{< api-url "mio" >}}
-[`mio::net`]: {{< api-url "mio" >}}/net/index.html
-[`mio::unix`]: {{< api-url "mio" >}}/unix/index.html
-[`Poll`]: {{< api-url "mio" >}}/struct.Poll.html
-[`Poll::poll`]: {{< api-url "mio" >}}/struct.Poll.html#method.poll
-[`register`]: {{< api-url "mio" >}}/struct.Poll.html#method.register
-[`std::fs`]: https://doc.rust-lang.org/std/fs/struct.File.html#implementations
-[`std::io`]: https://doc.rust-lang.org/std/io/#read-and-write
 [`std::net` examples]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#examples
-[`TCP sockets`]: {{< api-url "tokio" >}}/net/tcp/index.html
 [`tokio`]: {{< api-url "tokio" >}}
-[`Tokio::reactor`]: {{< api-url "tokio-reactor" >}}
-[`UDP sockets`]: {{< api-url "tokio" >}}/net/udp/index.html
-[`Unix sockets`]: {{< api-url "tokio" >}}/net/unix/index.html
+[`Tokio::fs`]: {{< api-url "tokio" >}}/fs/index.html
 [cross platform]: {{< api-url "mio" >}}/#platforms
+[File operations]: {{< api-url "tokio" >}}/fs/index.html
+[TCP sockets]: {{< api-url "tokio" >}}/net/tcp/index.html
+[UDP sockets]: {{< api-url "tokio" >}}/net/udp/index.html
+[Unix sockets]: {{< api-url "tokio" >}}/net/unix/index.html

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -6,7 +6,18 @@ menu:
     parent: io
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+Rust [`std::io`] module provides traits that synchronously access resources like
+files and sockets.  These `Read` and `Write` traits are implemented in other
+modules including [`std::fs`] and `std::net`.
 
-[doc-push]: https://github.com/tokio-rs/doc-push
+The [`tokio`] crate comes with a variation on those types, [`AsyncRead`] and
+[`AsyncWrite`].  The primary difference between [`AsyncRead`] and `std::io::Read`
+is the [`futures::Async`] return values.  The implementation returns an `Error`,
+`NotReady`, or `Ready` value.
+
+[`AsyncRead`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html
+[`AsyncWrite`]: {{< api-url "tokio" >}}/io/trait.AsyncWrite.html
+[`futures::Async`]: https://docs.rs/futures/0.1.18/futures/enum.Async.html
+[`std::io`]: https://doc.rust-lang.org/std/io/#read-and-write
+[`std::fs`]: https://doc.rust-lang.org/std/fs/struct.File.html#implementations
+[`tokio`]: {{< api-url "tokio" >}}

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -47,12 +47,19 @@ fn main() -> io::Result<()> {
 This single-threaded process will evaluate through calling `.incoming()` on
 the `TcpListener` and will continue to run until receiving a KILL signal from
 the operating system or until enough data is received on the TCP port to flush
-the buffer.
+the buffer, and reevaluating `.incoming()`.
+
+`Tokio` I/O, rather than pausing execution, uses a `Futures` based syntax to
+allow an event loop to respond to I/O rather than wait for it.  That event loop
+is [`Tokio::reactor`] which receives events from [`mio`].
+
 
 [`AsyncRead`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html
 [`AsyncWrite`]: {{< api-url "tokio" >}}/io/trait.AsyncWrite.html
-[`futures::Async`]: https://docs.rs/futures/0.1.18/futures/enum.Async.html
-[`std::io`]: https://doc.rust-lang.org/std/io/#read-and-write
+[`futures::Async`]: {{< api-url "futures" >}}/enum.Async.html
+[`mio`]: https://docs.rs/mio/*/mio/
 [`std::fs`]: https://doc.rust-lang.org/std/fs/struct.File.html#implementations
+[`std::io`]: https://doc.rust-lang.org/std/io/#read-and-write
 [`std::net` examples]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#examples
 [`tokio`]: {{< api-url "tokio" >}}
+[`Tokio::reactor`]: {{< api-url "tokio-reactor" >}}

--- a/layouts/shortcodes/api-url.html
+++ b/layouts/shortcodes/api-url.html
@@ -14,6 +14,8 @@
 {{- .Site.Params.coreDocsURL -}}
 {{- else if eq (.Get 0) "futures" -}}
 {{- .Site.Params.futuresDocsURL -}}
+{{- else if eq (.Get 0) "mio" -}}
+{{- .Site.Params.mioDocsURL -}}
 {{- else if eq (.Get 0) "proto" -}}
 {{- .Site.Params.protoDocsURL -}}
 {{- else if eq (.Get 0) "service" -}}

--- a/layouts/shortcodes/api-url.html
+++ b/layouts/shortcodes/api-url.html
@@ -4,6 +4,8 @@
 {{- .Site.Params.tokioExecutorDocsURL -}}
 {{- else if eq (.Get 0) "tokio-io" -}}
 {{- .Site.Params.tokioIoDocsURL -}}
+{{- else if eq (.Get 0) "tokio-reactor" -}}
+{{- .Site.Params.tokioReactorDocsURL -}}
 {{- else if eq (.Get 0) "tokio-timer" -}}
 {{- .Site.Params.tokioTimerDocsURL -}}
 {{- else if eq (.Get 0) "bytes" -}}


### PR DESCRIPTION
[LIVE](https://www.yetanother.site/website/docs/io/overview/)

The IO Overview will include:

> Functions as an introduction / tutorial to using I/O with Tokio.
> Comes w/ TCP, UDP, Unix
> Non-blocking
> Backed by Mio
> based on runtime model (previous section).
> Setup a TCP server
> Connect with TcpStream
> Send some data using io::write_all
> Read data on server, print, and close socket (note on drop).

[doc-push outline](https://github.com/tokio-rs/doc-push/blob/master/outline/io-with-tokio.md#overview)