### PR TITLE
[New] Improve hello-world consistency - hello_world and stream should be client

### DIFF
--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -57,7 +57,7 @@ by Tokio.
 fn main() {
     // Parse the address of whatever server we're talking to
     let addr = "127.0.0.1:6142".parse().unwrap();
-    let stream = TcpStream::connect(&addr);
+    let client = TcpStream::connect(&addr);
 
     // Following snippets come here...
 }
@@ -74,7 +74,7 @@ and then yield the stream once it's been created for additional processing.
 # use tokio::prelude::*;
 # fn main() {
 # let addr = "127.0.0.1:6142".parse().unwrap();
-let hello_world = TcpStream::connect(&addr).and_then(|stream| {
+let client = TcpStream::connect(&addr).and_then(|stream| {
     println!("created stream");
 
     // Process stream here.


### PR DESCRIPTION
Rename `hello_world`, `stream`, and `client` to `client`.

A cleaned up PR of #234 