### PR TITLE
Change to soft-linebreaks

### DIFF
--- a/content/blog/2017-01-tokio-0-1.md
+++ b/content/blog/2017-01-tokio-0-1.md
@@ -8,50 +8,22 @@ weight = 999
 
 Today we are publishing the preliminary version of the Tokio stack, 0.1!
 
-**Tokio is a platform for writing fast networking code in Rust.** It's built on
-futures,
-[a zero-cost abstraction for asynchronous programming in Rust](http://aturon.github.io/blog/2016/08/11/futures/).
-It provides a suite of basic tools, `tokio-core`, for asynchronous I/O with
-futures.  It also provides a higher-level layer, `tokio-proto`, for easily
-building sophisticated servers and clients; all you have to do is handle message
-serialization. You can use the Tokio stack to handle a wide range of protocols,
-including streaming and multiplexed protocols, as well as more specialized
-servers like proxies.
+**Tokio is a platform for writing fast networking code in Rust.** It's built on futures, [a zero-cost abstraction for asynchronous programming in Rust](http://aturon.github.io/blog/2016/08/11/futures/). It provides a suite of basic tools, `tokio-core`, for asynchronous I/O with futures.  It also provides a higher-level layer, `tokio-proto`, for easily building sophisticated servers and clients; all you have to do is handle message serialization. You can use the Tokio stack to handle a wide range of protocols, including streaming and multiplexed protocols, as well as more specialized servers like proxies.
 
-**Tokio is primarily intended as a foundation for other libraries**, in
-particular for high performance protocol implementations. Over time, we expect
-Tokio to grow a rich middleware ecosystem and ultimately to support various web
-and application frameworks. [Hyper], for example, has been adding Tokio
-integration, and there's a [growing list] of other protocol implementations as
-well.
+**Tokio is primarily intended as a foundation for other libraries**, in particular for high performance protocol implementations. Over time, we expect Tokio to grow a rich middleware ecosystem and ultimately to support various web and application frameworks. [Hyper], for example, has been adding Tokio integration, and there's a [growing list] of other protocol implementations as well.
 
 [Hyper]: http://hyper.rs/
 [growing list]: {{ relref "../community/third-party.md" }}
 
-Along with this initial release, **we're publishing
-[documentation]({{ ref "/docs/getting-started.md" }})** on this web site, ranging from
-getting started guides to meatier examples to deep dives into the implementation
-of the stack. Please take a look, and
-[let us know](https://github.com/tokio-rs/website/issues) what needs to be
-improved!
+Along with this initial release, **we're publishing [documentation]({{ ref "/docs/getting-started.md" }})** on this web site, ranging from getting started guides to meatier examples to deep dives into the implementation of the stack. Please take a look, and [let us know](https://github.com/tokio-rs/website/issues) what needs to be improved!
 
-The 0.1 release is a **beta quality** release. The stack has undergone a fair
-amount of testing, usage, and feedback, but it's still early days, and we don't
-have a lot of production use under our belt yet. Intrepid users are welcomed to
-work toward production usage, but you should expect bugs and limitations. The
-[gitter channel] is active and helpful for both learning and debugging.
+The 0.1 release is a **beta quality** release. The stack has undergone a fair amount of testing, usage, and feedback, but it's still early days, and we don't have a lot of production use under our belt yet. Intrepid users are welcomed to work toward production usage, but you should expect bugs and limitations. The [gitter channel] is active and helpful for both learning and debugging.
 
 [gitter channel]: https://gitter.im/tokio-rs/tokio
 
-This release also represents a point of **relative stability** for the library,
-which has been undergoing frequent breaking changes up until now. While we do
-intend to eventually publish a 0.2 release with breaking changes, we will take
-steps to make migration easy and plan to maintain the 0.1 release in parallel
-for some time. Potential areas of breakage are flagged under the 0.2 milestone
-in our repositories; please take a look and leave your thoughts on those issues!
+This release also represents a point of **relative stability** for the library, which has been undergoing frequent breaking changes up until now. While we do intend to eventually publish a 0.2 release with breaking changes, we will take steps to make migration easy and plan to maintain the 0.1 release in parallel for some time. Potential areas of breakage are flagged under the 0.2 milestone in our repositories; please take a look and leave your thoughts on those issues!
 
-Looking ahead, there are several major areas we're hoping to pursue after this
-release:
+Looking ahead, there are several major areas we're hoping to pursue after this release:
 
 - Starting to build out a middleware ecosystem, built on top of [tokio-service].
 - Resolving remaining questions about backpressure.
@@ -59,8 +31,7 @@ release:
   providing more tools for clients.
 - Completing a full HTTP/2 implementation.
 
-And in general, we are eager to support the growing Tokio ecosystem. Come kick
-the tires, try to build something, and let us know what can be improved!
+And in general, we are eager to support the growing Tokio ecosystem. Come kick the tires, try to build something, and let us know what can be improved!
 
 <div style="text-align:right">&mdash;Carl Lerche, Alex Crichton, and Aaron Turon</div>
 

--- a/content/blog/2017-03-tokio-io.md
+++ b/content/blog/2017-03-tokio-io.md
@@ -6,114 +6,45 @@ menu = "blog"
 weight = 998
 +++
 
-Today we're happy to announce a new crate and several new tools to work with
-in the Tokio stack. This represents the culmination of a number of parallel
-updates to various bits and pieces, they just happened to conveniently land all
-around the same time! In a nutshell the improvements are:
+Today we're happy to announce a new crate and several new tools to work with in the Tokio stack. This represents the culmination of a number of parallel updates to various bits and pieces, they just happened to conveniently land all around the same time! In a nutshell the improvements are:
 
-* A new [tokio-io] crate extracted from [tokio-core], deprecating the
-  [`tokio_core::io`] module.
-* Introduction of the [bytes] crate to [tokio-io] allowing abstraction over
-  buffering and leveraging underlying functionality like vectored I/O.
-* Addition of a new method, `close`, to the `Sink` trait to express graceful
-  shutdown.
+* A new [tokio-io] crate extracted from [tokio-core], deprecating the [`tokio_core::io`] module.
+* Introduction of the [bytes] crate to [tokio-io] allowing abstraction over buffering and leveraging underlying functionality like vectored I/O.
+* Addition of a new method, `close`, to the `Sink` trait to express graceful shutdown.
 
-These changes improve the organization and abstractions of Tokio to address
-several long-standing concerns and should provide a stable foundation for all
-future development. At the same time, the changes are not breaking since the
-old `io` module is still available in deprecated form. You can start using all
-these crates immediately via `cargo update` and using the most recent `0.1.*`
-versions of the crates!
+These changes improve the organization and abstractions of Tokio to address several long-standing concerns and should provide a stable foundation for all future development. At the same time, the changes are not breaking since the old `io` module is still available in deprecated form. You can start using all these crates immediately via `cargo update` and using the most recent `0.1.*` versions of the crates!
 
 Let's dive a bit more into each change in detail to see what's available now.
 
 ## Adding a `tokio-io` crate
 
-The existing [`tokio_core::io`] module gives a number of useful abstractions
-but they're not specific to [tokio-core] itself, and the major purpose of the
-[tokio-io] crate is to provide these core utilities without the implication of
-a runtime. With [tokio-io] crates can depend on asynchronous I/O semantics
-without tying themselves to a particular runtime, for example [tokio-core].
-The [tokio-io] crate is intended to be similar to the [`std::io`] standard
-library module in terms of serving a common abstraction for the asynchronous
-ecosystem. The concepts and traits set forth in [tokio-io] are the foundation
-for all I/O done in the Tokio stack.
+The existing [`tokio_core::io`] module gives a number of useful abstractions but they're not specific to [tokio-core] itself, and the major purpose of the [tokio-io] crate is to provide these core utilities without the implication of a runtime. With [tokio-io] crates can depend on asynchronous I/O semantics without tying themselves to a particular runtime, for example [tokio-core]. The [tokio-io] crate is intended to be similar to the [`std::io`] standard library module in terms of serving a common abstraction for the asynchronous ecosystem. The concepts and traits set forth in [tokio-io] are the foundation for all I/O done in the Tokio stack.
 
-The primary contents of [tokio-io] are the [`AsyncRead`] and [`AsyncWrite`]
-traits. These two traits are sort of a "split [`Io`] trait" and were chosen to
-demarcate types which implement Tokio-like read/write semantics (nonblocking
-and notifying to a future's task). These traits then integrate with the [bytes]
-crate to provide some convenient functions and retain old functionality like
-[`split`].
+The primary contents of [tokio-io] are the [`AsyncRead`] and [`AsyncWrite`] traits. These two traits are sort of a "split [`Io`] trait" and were chosen to demarcate types which implement Tokio-like read/write semantics (nonblocking and notifying to a future's task). These traits then integrate with the [bytes] crate to provide some convenient functions and retain old functionality like [`split`].
 
-With a clean slate we also took the chance to refresh the [`Codec`] trait in the
-[tokio-core] crate to [`Encoder`] and [`Decoder`] traits which operate over
-types in the [bytes] crate ([`EasyBuf`] is not present in [tokio-io] and it's
-now deprecated in [tokio-core]). These types allows you to quickly move from a
-stream of bytes to a [`Sink`] and a [`Stream`] ready to accept framed messages.
-A great example of this is that with [tokio-io] we can use the new
-[`length_delimited`] module combined with [tokio-serde-json] to get up and
-running with a JSON RPC server in no time as we'll see later in this post.
+With a clean slate we also took the chance to refresh the [`Codec`] trait in the [tokio-core] crate to [`Encoder`] and [`Decoder`] traits which operate over types in the [bytes] crate ([`EasyBuf`] is not present in [tokio-io] and it's now deprecated in [tokio-core]). These types allows you to quickly move from a stream of bytes to a [`Sink`] and a [`Stream`] ready to accept framed messages. A great example of this is that with [tokio-io] we can use the new [`length_delimited`] module combined with [tokio-serde-json] to get up and running with a JSON RPC server in no time as we'll see later in this post.
 
-Overall with [tokio-io] we were also able to revisit several minor issues in
-the API designed. This in turns empowered us to [close a slew of
-issues][closing] against [tokio-core]. We feel [tokio-io] is a great addition
-to the Tokio stack moving forward. Crates can choose to be abstract over
-[tokio-io] without pulling in runtimes such as [tokio-core], if they'd like.
+Overall with [tokio-io] we were also able to revisit several minor issues in the API designed. This in turns empowered us to [close a slew of issues][closing] against [tokio-core]. We feel [tokio-io] is a great addition to the Tokio stack moving forward. Crates can choose to be abstract over [tokio-io] without pulling in runtimes such as [tokio-core], if they'd like.
 
 ## Integration with `bytes`
 
-One longstanding wart with [tokio-core] is its [`EasyBuf`] byte buffer type.
-This type is basically what it says on the tin (an "easy" buffer) but is
-unfortunately typically not what you want in high performance use cases. We've
-long wanted to have a better abstraction (and a better concrete implementation)
-here.
+One longstanding wart with [tokio-core] is its [`EasyBuf`] byte buffer type. This type is basically what it says on the tin (an "easy" buffer) but is unfortunately typically not what you want in high performance use cases. We've long wanted to have a better abstraction (and a better concrete implementation) here.
 
-With [tokio-io] you'll find that the [bytes] crate on [crates.io] is much more
-tightly integrated and provides the abstractions necessary for high-performance
-and "easy" buffers simultaneously. The main contents of the [bytes] crate are
-the [`Buf`] and [`BufMut`] traits. These two traits serve as the ability to
-abstract over arbitrary byte buffers (both readable and writable) and are
-integrated with [`read_buf`] and [`write_buf`] on all asynchronous I/O objects
-now.
+With [tokio-io] you'll find that the [bytes] crate on [crates.io] is much more tightly integrated and provides the abstractions necessary for high-performance and "easy" buffers simultaneously. The main contents of the [bytes] crate are the [`Buf`] and [`BufMut`] traits. These two traits serve as the ability to abstract over arbitrary byte buffers (both readable and writable) and are integrated with [`read_buf`] and [`write_buf`] on all asynchronous I/O objects now.
 
-In addition to traits to abstract over many kinds of buffers the [bytes] crate
-comes with two high-quality implementations of these traits, the [`Bytes`] and
-[`BytesMut`] type (implementing the [`Buf`] and [`BufMut`] traits respectively).
-In a nutshell these types represent reference-counted buffers which allow
-zero-copy extraction of slices of data in an efficient fashion. To boot they
-also support a wide array of common operations such as tiny buffers (inline
-storage), single owners (can use a `Vec` internally), shared owners with
-disjoint views (`BytesMut`), and shared owners with possibly overlapping views
-(`Bytes`).
+In addition to traits to abstract over many kinds of buffers the [bytes] crate comes with two high-quality implementations of these traits, the [`Bytes`] and [`BytesMut`] type (implementing the [`Buf`] and [`BufMut`] traits respectively). In a nutshell these types represent reference-counted buffers which allow zero-copy extraction of slices of data in an efficient fashion. To boot they also support a wide array of common operations such as tiny buffers (inline storage), single owners (can use a `Vec` internally), shared owners with disjoint views (`BytesMut`), and shared owners with possibly overlapping views (`Bytes`).
 
-Overall the [bytes] crate we hope is your one-stop-shop for byte buffer
-abstractions as well as high-quality implementations to get you running
-quickly. We're excited to see what's in store for the [bytes] crate!
+Overall the [bytes] crate we hope is your one-stop-shop for byte buffer abstractions as well as high-quality implementations to get you running quickly. We're excited to see what's in store for the [bytes] crate!
 
 ## Addition of `Sink::close`
 
-The final major change that we've landed recently is the addition of a new
-method on the [`Sink`] trait, [`close`]. Up to now there hasn't been a great
-story around implementing "graceful shutdown" in a generic fashion because there
-was no clean way to indicate to a sink that no more items will be pushed into
-it. The new [`close`] method is intended precisely for this purpose.
+The final major change that we've landed recently is the addition of a new method on the [`Sink`] trait, [`close`]. Up to now there hasn't been a great story around implementing "graceful shutdown" in a generic fashion because there was no clean way to indicate to a sink that no more items will be pushed into it. The new [`close`] method is intended precisely for this purpose.
 
-The [`close`] method allows informing a sink that no more messages will be
-pushed into it. Sinks can then take this opportunity to flush messages and
-otherwise perform protocol-specific shutdown. For example a TLS connection at
-that point would initiate a shutdown operation or a proxied connection might
-issue a TCP-level shutdown. Typically this'll end up bottoming out to the new
-[`AsyncWrite::shutdown`] method.
+The [`close`] method allows informing a sink that no more messages will be pushed into it. Sinks can then take this opportunity to flush messages and otherwise perform protocol-specific shutdown. For example a TLS connection at that point would initiate a shutdown operation or a proxied connection might issue a TCP-level shutdown. Typically this'll end up bottoming out to the new [`AsyncWrite::shutdown`] method.
 
 ## Addition of `codec::length_delimited`
 
-One large feature that is landing with [tokio-io] is the addition of
-the [`length_delimited`] module (inspired by Netty's
-[`LengthFieldBasedFrameDecoder`]). Many protocols delimit frames by using a
-frame header that includes the length of the frame. As a simple example, take a
-protocol that uses a frame header of a `u32` to delimit the frame payload. Each
-frame on the wire looks like this:
+One large feature that is landing with [tokio-io] is the addition of the [`length_delimited`] module (inspired by Netty's [`LengthFieldBasedFrameDecoder`]). Many protocols delimit frames by using a frame header that includes the length of the frame. As a simple example, take a protocol that uses a frame header of a `u32` to delimit the frame payload. Each frame on the wire looks like this:
 
 ```text
 +----------+--------------------------------+
@@ -121,8 +52,7 @@ frame on the wire looks like this:
 +----------+--------------------------------+
 ```
 
-Parsing this protocol can easily be handled with
-[`length_delimited::Framed`]:
+Parsing this protocol can easily be handled with [`length_delimited::Framed`]:
 
 ```rust,ignore
 // Bind a server socket
@@ -136,12 +66,7 @@ socket.and_then(|socket| {
 })
 ```
 
-In the above example, `transport` will be a `Sink + Stream` of buffer
-values, where each buffer contains the frame payload. This makes
-encoding and decoding the frame to a value fairly easy to do with
-something like [serde]. For example, using [tokio-serde-json], we can
-quickly implement a JSON based protocol where each frame is length
-delimited and the frame payload is encoded using JSON:
+In the above example, `transport` will be a `Sink + Stream` of buffer values, where each buffer contains the frame payload. This makes encoding and decoding the frame to a value fairly easy to do with something like [serde]. For example, using [tokio-serde-json], we can quickly implement a JSON based protocol where each frame is length delimited and the frame payload is encoded using JSON:
 
 ```rust,ignore
 // Bind a server socket
@@ -170,9 +95,7 @@ socket.and_then(|socket| {
 
 The full example is [here](https://github.com/carllerche/tokio-serde-json/tree/master/examples).
 
-The [`length_delimited`] module contains enough configuration settings to
-handle parsing length delimited frames with more complex frame headers,
-like the HTTP/2.0 protocol.
+The [`length_delimited`] module contains enough configuration settings to handle parsing length delimited frames with more complex frame headers, like the HTTP/2.0 protocol.
 
 [serde]: https://serde.rs/
 [tokio-serde-json]: https://github.com/carllerche/tokio-serde-json
@@ -181,20 +104,9 @@ like the HTTP/2.0 protocol.
 
 ## What's next?
 
-All of these changes put together closes quite a large number of issues in the
-[futures] and [tokio-core] crates and we feel positions Tokio precisely where
-we'd like it for common I/O and buffering abstractions. As always we'd love to
-hear feedback on issue trackers and are more than willing to merge PRs if you
-find a problem! Otherwise we look forward to seeing all of these changes in
-practice!
+All of these changes put together closes quite a large number of issues in the [futures] and [tokio-core] crates and we feel positions Tokio precisely where we'd like it for common I/O and buffering abstractions. As always we'd love to hear feedback on issue trackers and are more than willing to merge PRs if you find a problem! Otherwise we look forward to seeing all of these changes in practice!
 
-With the foundations of [tokio-core], [tokio-io], [tokio-service], and
-[tokio-proto] solidifying the Tokio team is looking forward to accommodating
-and implementing more ambitious protocols such as HTTP/2. We're working closely
-with [@seanmonstar][sean] and [Hyper] to develop these foundational HTTP
-libraries as well. Finally we're looking to expand the middleware story in the
-near future with relation to both HTTP and generic [tokio-service]
-implementations. More on this coming soon!
+With the foundations of [tokio-core], [tokio-io], [tokio-service], and [tokio-proto] solidifying the Tokio team is looking forward to accommodating and implementing more ambitious protocols such as HTTP/2. We're working closely with [@seanmonstar][sean] and [Hyper] to develop these foundational HTTP libraries as well. Finally we're looking to expand the middleware story in the near future with relation to both HTTP and generic [tokio-service] implementations. More on this coming soon!
 
 [`AsyncWrite::shutdown`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncWrite.html#tymethod.shutdown
 [`close`]: https://docs.rs/futures/0.1/futures/sink/trait.Sink.html#method.close

--- a/content/blog/2017-09-tokio-reform.md
+++ b/content/blog/2017-09-tokio-reform.md
@@ -8,46 +8,25 @@ weight = 997
 
 Hi there, Tokio community!
 
-Carl, Alex, and myself have been hard at work developing ways to simplify,
-streamline, and focus the Tokio project. As part of this effort, we have
-written the first-ever Tokio [RFC]!
+Carl, Alex, and myself have been hard at work developing ways to simplify, streamline, and focus the Tokio project. As part of this effort, we have written the first-ever Tokio [RFC]!
 
 Here's a quick run-down of what's being proposed.
 
-* Add a global event loop in `tokio-core` that is managed automatically by
-  default. This change eliminates the need for setting up and managing your own
-  event loop in the vast majority of cases.
+* Add a global event loop in `tokio-core` that is managed automatically by default. This change eliminates the need for setting up and managing your own event loop in the vast majority of cases.
 
-  * Moreover, remove the distinction between `Handle` and `Remote` in
-  `tokio-core` by making `Handle` both `Send` and `Sync` and deprecating
-  `Remote`. Thus, even working with custom event loops becomes simpler.
+  * Moreover, remove the distinction between `Handle` and `Remote` in `tokio-core` by making `Handle` both `Send` and `Sync` and deprecating `Remote`. Thus, even working with custom event loops becomes simpler.
 
-* Decouple all task execution functionality from Tokio, instead providing it
-  through a standard futures component. As with event loops, provide a default
-  global thread pool that suffices for the majority of use-cases, removing the
-  need for any manual setup.
+* Decouple all task execution functionality from Tokio, instead providing it through a standard futures component. As with event loops, provide a default global thread pool that suffices for the majority of use-cases, removing the need for any manual setup.
 
-  * Moreover, when running tasks thread-locally (for non-`Send` futures),
-    provide more fool-proof APIs that help avoid lost wakeups.
+  * Moreover, when running tasks thread-locally (for non-`Send` futures), provide more fool-proof APIs that help avoid lost wakeups.
 
-* Provide the above changes in a new `tokio` crate, which is a slimmed down
-  version of today's `tokio-core`, and may *eventually* re-export the contents
-  of `tokio-io`. The `tokio-core` crate is deprecated, but will remain available
-  for backward compatibility. In the long run, most users should only need to
-  depend on `tokio` to use the Tokio stack.
+* Provide the above changes in a new `tokio` crate, which is a slimmed down version of today's `tokio-core`, and may *eventually* re-export the contents of `tokio-io`. The `tokio-core` crate is deprecated, but will remain available for backward compatibility. In the long run, most users should only need to depend on `tokio` to use the Tokio stack.
 
-* Focus documentation primarily on `tokio`, rather than on
-  `tokio-proto`. Provide a much more extensive set of cookbook-style examples
-  and general guidelines, as well as a more in-depth guide to working with
-  futures.
+* Focus documentation primarily on `tokio`, rather than on `tokio-proto`. Provide a much more extensive set of cookbook-style examples and general guidelines, as well as a more in-depth guide to working with futures.
 
-Altogether, these changes, together with [async/await], should go a long
-distance toward making Tokio a newcomer-friendly library. Please take a look at
-the [RFC] and leave your feedback!
+Altogether, these changes, together with [async/await], should go a long distance toward making Tokio a newcomer-friendly library. Please take a look at the [RFC] and leave your feedback!
 
-Once we've reached consensus on the RFC, we plan to form an impl period *working
-group*, focused primarily on docs and examples. And from there, we will be
-working with the Hyper team to figure out the next chapter of that story. Stay tuned!
+Once we've reached consensus on the RFC, we plan to form an impl period *working group*, focused primarily on docs and examples. And from there, we will be working with the Hyper team to figure out the next chapter of that story. Stay tuned!
 
 
 <div style="text-align:right">&mdash;Aaron Turon</div>

--- a/content/blog/2018-02-tokio-reform-shipped.md
+++ b/content/blog/2018-02-tokio-reform-shipped.md
@@ -8,98 +8,55 @@ weight = 996
 
 Hi all!
 
-I'm happy to announce that today, the changes proposed in the [reform RFC] have
-been released to [crates.io] as `tokio` 0.1.
+I'm happy to announce that today, the changes proposed in the [reform RFC] have been released to [crates.io] as `tokio` 0.1.
 
 The primary changes are:
 
-* Add a *default* global event loop, eliminating the need for setting up and
-  managing your own event loop in the vast majority of cases.
+* Add a *default* global event loop, eliminating the need for setting up and managing your own event loop in the vast majority of cases.
 
 * Decouple all task execution functionality from Tokio.
 
 ## The new global event loop
 
-Up until today, creating an event loop was a manual process. Even though the
-vast majority of Tokio users would setup the reactor to do the same thing,
-everyone had to do it each time. This was partially due to the fact that there
-was a significant difference between running code on the Tokio reactor's thread
-or from another thread (like a thread pool).
+Up until today, creating an event loop was a manual process. Even though the vast majority of Tokio users would setup the reactor to do the same thing, everyone had to do it each time. This was partially due to the fact that there was a significant difference between running code on the Tokio reactor's thread or from another thread (like a thread pool).
 
-The key insight that allowed for the Tokio reform changes is that the Tokio
-reactor doesn't actually have to be an executor. In other words, prior to these
-changes, the Tokio reactor would both power I/O resources **and** manage
-executing user submitted tasks.
+The key insight that allowed for the Tokio reform changes is that the Tokio reactor doesn't actually have to be an executor. In other words, prior to these changes, the Tokio reactor would both power I/O resources **and** manage executing user submitted tasks.
 
-Now, Tokio provides a reactor to drive I/O resources (like `TcpStream` and
-`UdpSocket`) separately from the task executor. This means that it is easy to
-create Tokio-backed networking types from *any* thread, making it easy to create
-either single or multi threaded Tokio-backed apps.
+Now, Tokio provides a reactor to drive I/O resources (like `TcpStream` and `UdpSocket`) separately from the task executor. This means that it is easy to create Tokio-backed networking types from *any* thread, making it easy to create either single or multi threaded Tokio-backed apps.
 
-For task execution, Tokio provides the [`current_thread`] executor, which
-behaves similarly to how the built-in tokio-core executor did. The plan is to
-eventually move this executor into the [`futures`] crate, but for now it is
-provided directly by Tokio.
+For task execution, Tokio provides the [`current_thread`] executor, which behaves similarly to how the built-in tokio-core executor did. The plan is to eventually move this executor into the [`futures`] crate, but for now it is provided directly by Tokio.
 
 ## The road to 0.2
 
-The Tokio reform changes have been released as 0.1. Dependencies ([`tokio-io`],
-[`futures`], [`mio`], etc...) have not had their versions incremented. This
-allows the `tokio` crate to be released with minimal ecosystem disruption.
+The Tokio reform changes have been released as 0.1. Dependencies ([`tokio-io`], [`futures`], [`mio`], etc...) have not had their versions incremented. This allows the `tokio` crate to be released with minimal ecosystem disruption.
 
-The plan is to let the changes made in this release get some usage before
-committing to them. Any fixes that require breaking changes will be able to be
-done at the same time as the release to all the other crates. The goal is for
-this to happen in 6-8 weeks. So please try out the changes released today and
-provide feedback.
+The plan is to let the changes made in this release get some usage before committing to them. Any fixes that require breaking changes will be able to be done at the same time as the release to all the other crates. The goal is for this to happen in 6-8 weeks. So please try out the changes released today and provide feedback.
 
 ## Rapid iteration
 
-This is just the beginning. Tokio has ambitious goals to provide additional
-functionality to get a great "out of the box" experience building asynchronous
-I/O applications in Rust.
+This is just the beginning. Tokio has ambitious goals to provide additional functionality to get a great "out of the box" experience building asynchronous I/O applications in Rust.
 
-In order to reach these goals as fast as possible without causing unnecessary
-ecosystem disruption, we will be taking a few steps.
+In order to reach these goals as fast as possible without causing unnecessary ecosystem disruption, we will be taking a few steps.
 
-First, similarly to the [`futures` 0.2 release], the `tokio` crate will be
-transitioned to be more of a facade. Traits and types will be broken up into a
-number of sub crates and re-exported by `tokio`. Application authors will be
-able to depend directly on `tokio` while library authors will pick and choose
-the specific Tokio components that they wish to use as part of their libraries.
+First, similarly to the [`futures` 0.2 release], the `tokio` crate will be transitioned to be more of a facade. Traits and types will be broken up into a number of sub crates and re-exported by `tokio`. Application authors will be able to depend directly on `tokio` while library authors will pick and choose the specific Tokio components that they wish to use as part of their libraries.
 
-Each sub crate will clearly indicate its stability level. Obviously, there is an
-upcoming breaking change with the futures 0.2 release, but after that,
-fundamental building blocks will aim to remain stable for at least a year. More
-experimental crates will reserve the right to issue breaking changes at a
-quicker pace.
+Each sub crate will clearly indicate its stability level. Obviously, there is an upcoming breaking change with the futures 0.2 release, but after that, fundamental building blocks will aim to remain stable for at least a year. More experimental crates will reserve the right to issue breaking changes at a quicker pace.
 
-This means that the `tokio` crate itself will be able to iterate at a faster
-pace while the library ecosystem remains stable.
+This means that the `tokio` crate itself will be able to iterate at a faster pace while the library ecosystem remains stable.
 
-The pre 0.2 period will also be a period of experimentation. Additional
-functionality will be added to Tokio in an experimental capacity. Before an 0.2
-release, an RFC will be posted covering the functionality that we would like to
-include in that release.
+The pre 0.2 period will also be a period of experimentation. Additional functionality will be added to Tokio in an experimental capacity. Before an 0.2 release, an RFC will be posted covering the functionality that we would like to include in that release.
 
 ## Open question
 
-One remaining question is what to do about `tokio-proto`. It was released as
-part of the initial Tokio release. Since then, the focus has shifted and that
-crate has not received enough attention.
+One remaining question is what to do about `tokio-proto`. It was released as part of the initial Tokio release. Since then, the focus has shifted and that crate has not received enough attention.
 
-I posted an issue to discuss what to do with that crate
-[here](https://github.com/tokio-rs/tokio/issues/118)
+I posted an issue to discuss what to do with that crate [here](https://github.com/tokio-rs/tokio/issues/118)
 
 ## Looking Forward
 
-Please try out the changes released today. Again, the next couple of months are a period
-of experimentation before we commit on the next release. So, now is the time to try things
-out and provide feedback.
+Please try out the changes released today. Again, the next couple of months are a period of experimentation before we commit on the next release. So, now is the time to try things out and provide feedback.
 
-During this time, we'll be integrating this work to build out higher-level
-primitives in [Tower], which is being driven by the production operational needs
-of the [Conduit] project.
+During this time, we'll be integrating this work to build out higher-level primitives in [Tower], which is being driven by the production operational needs of the [Conduit] project.
 
 <div style="text-align:right">&mdash;Carl Lerche</div>
 

--- a/content/blog/2018-03-timers.md
+++ b/content/blog/2018-03-timers.md
@@ -8,62 +8,38 @@ weight = 994
 
 Happy Friday all!
 
-To close out a great week, there is a [new release] of Tokio. This release
-includes a brand new timer implementation.
+To close out a great week, there is a [new release] of Tokio. This release includes a brand new timer implementation.
 
 ## Timers
 
-Sometimes (often), one wants to execute code in relation to time. Maybe a
-function needs to run at a specific instant. Maybe a read needs to be limited
-to a fixed duration. For working with time, one needs access to a timer!
+Sometimes (often), one wants to execute code in relation to time. Maybe a function needs to run at a specific instant. Maybe a read needs to be limited to a fixed duration. For working with time, one needs access to a timer!
 
 ## Some history
 
-The `tokio-timer` crate has been around for a while. It was originally built
-using a [hashed timer wheel][wheel] (pdf warning). It had a granularity of 100
-milliseconds, so any timeout set with a resolution of less than 100 milliseconds
-would get rounded up. Usually, in the context of network based applications,
-this is fine. Timeouts are usually at least 30 seconds and do not require high
-precision.
+The `tokio-timer` crate has been around for a while. It was originally built using a [hashed timer wheel][wheel] (pdf warning). It had a granularity of 100 milliseconds, so any timeout set with a resolution of less than 100 milliseconds would get rounded up. Usually, in the context of network based applications, this is fine. Timeouts are usually at least 30 seconds and do not require high precision.
 
-However, there are cases for which 100 milliseconds is too coarse. Also, the
-original implementation of Tokio timer had a number of annoying bugs and did not
-handle edge cases super well due to the implementation strategy it took.
+However, there are cases for which 100 milliseconds is too coarse. Also, the original implementation of Tokio timer had a number of annoying bugs and did not handle edge cases super well due to the implementation strategy it took.
 
 ## A new beginning
 
-The timer has been rewritten from scratch and released as [`tokio-timer`
-0.2][2]. For the most part, the API is pretty similar, but implementation is
-completely different.
+The timer has been rewritten from scratch and released as [`tokio-timer` 0.2][2]. For the most part, the API is pretty similar, but implementation is completely different.
 
-Instead of just using a single hashed timer wheel implementation, it uses a
-hierarchical approach (also described in the paper linked above).
+Instead of just using a single hashed timer wheel implementation, it uses a hierarchical approach (also described in the paper linked above).
 
-The timer uses six separate levels. Each level is a hashed wheel containing 64
-slots. Slots in the lowest level represent one millisecond. The
-next level up represents 64 milliseconds (1 x 64 slots) and so on. So, a slot on
-each level covers an equal amount of time as the entire level below.
+The timer uses six separate levels. Each level is a hashed wheel containing 64 slots. Slots in the lowest level represent one millisecond. The next level up represents 64 milliseconds (1 x 64 slots) and so on. So, a slot on each level covers an equal amount of time as the entire level below.
 
-When a timeout is set, if it is within 64 milliseconds from the current instant,
-it goes in the lowest level. If the timeout is within 64 milliseconds and 4,096
-milliseconds, it goes in the second level, and so on.
+When a timeout is set, if it is within 64 milliseconds from the current instant, it goes in the lowest level. If the timeout is within 64 milliseconds and 4,096 milliseconds, it goes in the second level, and so on.
 
-As time advances, timeouts in the lowest level are fired. Once the end of the
-lowest level is reached, all timeouts in the next level up are removed from that
-level and moved to the lowest level.
+As time advances, timeouts in the lowest level are fired. Once the end of the lowest level is reached, all timeouts in the next level up are removed from that level and moved to the lowest level.
 
-Using this strategy, all timer operations (creating a timeout, canceling a
-timeout, firing a timeout) are constant. This results in very good performance
-even with a very large number of outstanding timeouts.
+Using this strategy, all timer operations (creating a timeout, canceling a timeout, firing a timeout) are constant. This results in very good performance even with a very large number of outstanding timeouts.
 
 ## A quick look at the API.
 
-As mentioned above, the API has not really changed. There are three primary
-types:
+As mentioned above, the API has not really changed. There are three primary types:
 
 * [`Delay`][delay]: A future that completes at a set instant in time.
-* [`Deadline`][deadline]: Decorates a future ensuring it completes before the
-  deadline is reached.
+* [`Deadline`][deadline]: Decorates a future ensuring it completes before the deadline is reached.
 * [`Interval`][interval]: A stream that yields values at a fixed intervals.
 
 And a quick example:
@@ -90,27 +66,17 @@ fn main() {
 }
 ```
 
-The above example creates a new `Delay` instance that will complete 100
-milliseconds in the future. The `new` function takes an `Instant`, so we compute
-`when` to be the instant 100 milliseconds from now.
+The above example creates a new `Delay` instance that will complete 100 milliseconds in the future. The `new` function takes an `Instant`, so we compute `when` to be the instant 100 milliseconds from now.
 
-Once the instant is reached, the `Delay` future completes, resulting in the
-`and_then` block to be executed.
+Once the instant is reached, the `Delay` future completes, resulting in the `and_then` block to be executed.
 
-This release comes with a short [guide] explaining how to use timers and [API
-documentation][api].
+This release comes with a short [guide] explaining how to use timers and [API documentation][api].
 
 ## Integrated in the Runtime
 
-Using the timer API requires a timer instance to be running. The Tokio [runtime]
-takes care of all that setup for you.
+Using the timer API requires a timer instance to be running. The Tokio [runtime] takes care of all that setup for you.
 
-When the runtime is started with `tokio::run` or by calling `Runtime::new`
-directly, a thread pool is started. Each worker thread will get one timer
-instance. So, this means that if the runtime starts 4 worker threads, there will
-be 4 timer instances, one per thread. Doing this allows using the timer without
-paying a synchronization cost since the timer will be located on the same thread
-as the code that uses the various timer types (`Delay`, `Deadline`, `Interval`).
+When the runtime is started with `tokio::run` or by calling `Runtime::new` directly, a thread pool is started. Each worker thread will get one timer instance. So, this means that if the runtime starts 4 worker threads, there will be 4 timer instances, one per thread. Doing this allows using the timer without paying a synchronization cost since the timer will be located on the same thread as the code that uses the various timer types (`Delay`, `Deadline`, `Interval`).
 
 And with that, have a great weekend!
 

--- a/content/blog/2018-03-tokio-runtime.md
+++ b/content/blog/2018-03-tokio-runtime.md
@@ -6,8 +6,7 @@ menu = "blog"
 weight = 995
 +++
 
-I'm happy to announce a new release of Tokio. This release includes the first
-iteration of the Tokio Runtime.
+I'm happy to announce a new release of Tokio. This release includes the first iteration of the Tokio Runtime.
 
 ## tl;dr
 
@@ -35,9 +34,7 @@ let server = listener.incoming()
 tokio::run(server);
 ```
 
-where `process` represents a user defined function that takes a socket and
-returns a future that process it. In the case of an echo server, that might be
-reading all data from the socket and writing it back to the same socket.
+where `process` represents a user defined function that takes a socket and returns a future that process it. In the case of an echo server, that might be reading all data from the socket and writing it back to the same socket.
 
 The [guides] and [examples] have been updated to use the runtime.
 
@@ -46,72 +43,46 @@ The [guides] and [examples] have been updated to use the runtime.
 
 ## What is the Tokio Runtime?
 
-The Rust asynchronous stack is evolving to a set of loosely coupled components.
-To get a basic networking application running, you need at a minimum an
-asynchronous task executor and an instance of the Tokio reactor. Because
-everything is decoupled, there are multiple options for these various
-components, but this adds a bunch of boilerplate to all apps.
+The Rust asynchronous stack is evolving to a set of loosely coupled components. To get a basic networking application running, you need at a minimum an asynchronous task executor and an instance of the Tokio reactor. Because everything is decoupled, there are multiple options for these various components, but this adds a bunch of boilerplate to all apps.
 
-To help mitigate this, Tokio now provides the concept of a runtime. This is a
-pre-configured package of all the various components that are necessary for
-running the application.
+To help mitigate this, Tokio now provides the concept of a runtime. This is a pre-configured package of all the various components that are necessary for running the application.
 
-This initial release of the runtime includes the reactor as well as a
-[work-stealing] based thread pool for scheduling and executing the application's
-code. This provides a multi-threaded default for applications.
+This initial release of the runtime includes the reactor as well as a [work-stealing] based thread pool for scheduling and executing the application's code. This provides a multi-threaded default for applications.
 
-The work-stealing default is ideal for most applications. It uses a similar
-strategy as Go, Erlang, .NET, Java (the ForkJoin pool), etc... The
-implementation provided by Tokio is designed for use cases where many
-**unrelated** tasks are multiplexed on a single thread pool.
+The work-stealing default is ideal for most applications. It uses a similar strategy as Go, Erlang, .NET, Java (the ForkJoin pool), etc... The implementation provided by Tokio is designed for use cases where many **unrelated** tasks are multiplexed on a single thread pool.
 
 ## Using the Tokio Runtime
 
-As illustrated in the example above, the easiest way to use the Tokio runtime
-is with two functions:
+As illustrated in the example above, the easiest way to use the Tokio runtime is with two functions:
 
 * `tokio::run`
 * `tokio::spawn`.
 
-The first function takes a future to seed the application and starts the
-runtime. Roughly, it does the following:
+The first function takes a future to seed the application and starts the runtime. Roughly, it does the following:
 
 1. Start the reactor.
 2. Start the thread pool.
 3. Spawn the future onto the thread pool.
 4. Blocks the thread until the runtime becomes idle.
 
-The runtime becomes idle once **all** spawned futures have completed and **all**
-I/O resources bound to the reactor are dropped.
+The runtime becomes idle once **all** spawned futures have completed and **all** I/O resources bound to the reactor are dropped.
 
-From within the context of a runtime. The application may spawn additional
-futures onto the thread pool using `tokio::spawn`.
+From within the context of a runtime. The application may spawn additional futures onto the thread pool using `tokio::spawn`.
 
-Alternatively, the [`Runtime`] type can be used directly. This allows for more
-flexibility around setting up and using the runtime.
+Alternatively, the [`Runtime`] type can be used directly. This allows for more flexibility around setting up and using the runtime.
 
 [`Runtime`]: #
 
 ## Future improvements
 
-This is just the initial release of the Tokio runtime. Upcoming releases will
-include additional functionality that is useful for Tokio based applications. A
-blog post will be coming soon that goes into the roadmap in more detail.
+This is just the initial release of the Tokio runtime. Upcoming releases will include additional functionality that is useful for Tokio based applications. A blog post will be coming soon that goes into the roadmap in more detail.
 
-The goal, as mentioned before, is to release early and often. Providing new
-features to enable the community to experiment with them. Sometime in the next
-few months, there will be a breaking release of the entire Tokio stack, so any
-changes in the API need to be discovered before then.
+The goal, as mentioned before, is to release early and often. Providing new features to enable the community to experiment with them. Sometime in the next few months, there will be a breaking release of the entire Tokio stack, so any changes in the API need to be discovered before then.
 
 ## Tokio-core
 
-There has also been a new release of `tokio-core`. This release updates
-`tokio-core` to use `tokio` under the hood. This enables all existing
-applications and libraries that currently depend on `tokio-core` (like Hyper) to
-be able to use the improvements that come with the Tokio runtime without
-requiring a breaking change.
+There has also been a new release of `tokio-core`. This release updates `tokio-core` to use `tokio` under the hood. This enables all existing applications and libraries that currently depend on `tokio-core` (like Hyper) to be able to use the improvements that come with the Tokio runtime without requiring a breaking change.
 
-Given the amount of churn that is expected to happen in the next few months,
-we're hoping to help ease the transition across releases.
+Given the amount of churn that is expected to happen in the next few months, we're hoping to help ease the transition across releases.
 
 [work-stealing]: https://en.wikipedia.org/wiki/Work_stealing

--- a/content/blog/2018-05-tokio-fs.md
+++ b/content/blog/2018-05-tokio-fs.md
@@ -6,79 +6,41 @@ menu = "blog"
 weight = 993
 +++
 
-It took a bit longer than I had initially hoped (as it always does), but a new
-Tokio version has been released. This release includes, among other features, a
-new [set of APIs][fs] that allow performing filesystem operations from an
-asynchronous context.
+It took a bit longer than I had initially hoped (as it always does), but a new Tokio version has been released. This release includes, among other features, a new [set of APIs][fs] that allow performing filesystem operations from an asynchronous context.
 
 ## Filesystem APIs
 
-Interacting with files (and other filesystem types) requires\* blocking system
-calls and we all know that blocking and asynchronous do not mix. So,
-historically, when people ask "how do I read from and write to files?", the
-answer is to use a thread pool. The idea is that when a blocking read or
-write must be performed, it is done on a thread pool so that it does not block
-the asynchronous reactor.
+Interacting with files (and other filesystem types) requires\* blocking system calls and we all know that blocking and asynchronous do not mix. So, historically, when people ask "how do I read from and write to files?", the answer is to use a thread pool. The idea is that when a blocking read or write must be performed, it is done on a thread pool so that it does not block the asynchronous reactor.
 
-Requiring a separate thread pool for performing file operations requires message
-passing. The asynchronous task must send a message to the thread pool asking it
-to do a read from the file, the thread pool does the read and fills a buffer
-with the result. Then the thread pool sends the buffer back to the asynchronous
-task. Not only does this add the overhead for dispatching messages, but it also
-requires allocating buffers to send the data back and forth.
+Requiring a separate thread pool for performing file operations requires message passing. The asynchronous task must send a message to the thread pool asking it to do a read from the file, the thread pool does the read and fills a buffer with the result. Then the thread pool sends the buffer back to the asynchronous task. Not only does this add the overhead for dispatching messages, but it also requires allocating buffers to send the data back and forth.
 
-Now, with Tokio's new [filesystem APIs][fs], this message passing overhead is no
-longer needed. A new [`File`] type is added. This type looks very similar to the
-type provided by `std`, but it implements `AsyncRead` and `AsyncWrite`, making
-it safe to use *directly* from an asynchronous task running on the Tokio
-runtime.
+Now, with Tokio's new [filesystem APIs][fs], this message passing overhead is no longer needed. A new [`File`] type is added. This type looks very similar to the type provided by `std`, but it implements `AsyncRead` and `AsyncWrite`, making it safe to use *directly* from an asynchronous task running on the Tokio runtime.
 
-Because the [`File`] type implements `AsyncRead` and `AsyncWrite`, it can be
-used in much the same way that a TCP socket would be used from Tokio.
+Because the [`File`] type implements `AsyncRead` and `AsyncWrite`, it can be used in much the same way that a TCP socket would be used from Tokio.
 
-As of today, the filesystem APIs are pretty minimal. There are many other APIs
-that need to be implemented to bring the Tokio filesystem APIs in line with
-`std`, but those are left as an exercise to the reader to submit as PRs!
+As of today, the filesystem APIs are pretty minimal. There are many other APIs that need to be implemented to bring the Tokio filesystem APIs in line with `std`, but those are left as an exercise to the reader to submit as PRs!
 
-\* Yes, there are some operating systems that provide fully asynchronous
-filesystem APIs, but these are either incomplete or not portable.
+\* Yes, there are some operating systems that provide fully asynchronous filesystem APIs, but these are either incomplete or not portable.
 
 ## Standard in and out
 
-This release of Tokio also includes asynchronous [standard input][in] and
-[standard output][out] APIs. Because it is difficult to provide true
-asynchronous standard input and output in a portable way, the Tokio versions use
-a similar strategy as the blocking file operation APIs.
+This release of Tokio also includes asynchronous [standard input][in] and [standard output][out] APIs. Because it is difficult to provide true asynchronous standard input and output in a portable way, the Tokio versions use a similar strategy as the blocking file operation APIs.
 
 ## `blocking`
 
-These new APIs are made possible thanks to a new [`blocking`] API that allows
-annotating sections of code that will block the current thread. These blocking
-sections can include blocking system calls, waiting on mutexes, or CPU heavy
-computations.
+These new APIs are made possible thanks to a new [`blocking`] API that allows annotating sections of code that will block the current thread. These blocking sections can include blocking system calls, waiting on mutexes, or CPU heavy computations.
 
-By informing the Tokio runtime that the current thread will block, the runtime
-is able to move the event loop from the current thread to another thread,
-freeing the current thread up to permit blocking.
+By informing the Tokio runtime that the current thread will block, the runtime is able to move the event loop from the current thread to another thread, freeing the current thread up to permit blocking.
 
-This is the opposite of using message passing to run blocking operations on a
-threadpool. Instead of moving the blocking operation to another thread, the
-entire event loop is moved.
+This is the opposite of using message passing to run blocking operations on a threadpool. Instead of moving the blocking operation to another thread, the entire event loop is moved.
 
-In practice, moving the event loop to another thread is much cheaper than moving
-the blocking operation. Doing so only requires a few atomic operations. The
-Tokio runtime also keeps a pool of standby threads ready to allow moving the
-event loop as fast as possible.
+In practice, moving the event loop to another thread is much cheaper than moving the blocking operation. Doing so only requires a few atomic operations. The Tokio runtime also keeps a pool of standby threads ready to allow moving the event loop as fast as possible.
 
-This also means that using the `blocking` annotation and `tokio-fs` must be done
-from the context of the Tokio runtime and not other futures aware executors.
+This also means that using the `blocking` annotation and `tokio-fs` must be done from the context of the Tokio runtime and not other futures aware executors.
 
 ## Current thread runtime
 
-The release also includes a ["current thread"][rt] version of the runtime
-(thanks [kpp](https://github.com/kpp)). This is similar to the existing runtime,
-but runs all components on the current thread. This allows running futures that
-do not implement `Send`.
+The release also includes a ["current thread"][rt] version of the runtime (thanks [kpp](https://github.com/kpp)). This is similar to the existing runtime, but runs all components on the current thread. This allows running futures that do not implement `Send`.
 
 [fs]: https://docs.rs/tokio/0.1/tokio/fs/index.html
 [`File`]: https://docs.rs/tokio/0.1/tokio/fs/struct.File.html

--- a/content/blog/2018-08-async-await.md
+++ b/content/blog/2018-08-async-await.md
@@ -8,24 +8,15 @@ weight = 991
 
 Happy Monday!
 
-In case you haven't heard, `async` / `await` is a big new feature that is being
-worked on for Rust. It aims to make asynchronous programming easy (well, at
-least a little bit easier than it is today). The work has been on going for a
-while and is already usable today on the Rust nightly channel.
+In case you haven't heard, `async` / `await` is a big new feature that is being worked on for Rust. It aims to make asynchronous programming easy (well, at least a little bit easier than it is today). The work has been on going for a while and is already usable today on the Rust nightly channel.
 
-I'm happy to announce that Tokio now has experimental async / await support!
-Let's dig in a bit.
+I'm happy to announce that Tokio now has experimental async / await support! Let's dig in a bit.
 
 ## Getting started
 
-First, Tokio async/await support is provided by a new crate, creatively named
-[`tokio-async-await`]. This crate is a shim on top of `tokio`. It contains all of
-the same types and functions as `tokio` (as re-exports) as well as additional
-helpers to work with `async` / `await`.
+First, Tokio async/await support is provided by a new crate, creatively named [`tokio-async-await`]. This crate is a shim on top of `tokio`. It contains all of the same types and functions as `tokio` (as re-exports) as well as additional helpers to work with `async` / `await`.
 
-To use [`tokio-async-await`], you need to depend on it from a crate that is
-configured to use Rust's 2018 edition. It also only works with recent Rust
-nightly releases.
+To use [`tokio-async-await`], you need to depend on it from a crate that is configured to use Rust's 2018 edition. It also only works with recent Rust nightly releases.
 
 In your application's `Cargo.toml`, add the following:
 
@@ -67,8 +58,7 @@ cargo +nightly run
 
 and you are using Tokio + `async` / `await`!
 
-Note that, to spawn `async` blocks, the `tokio::run_async` function should be
-used (instead of `tokio::run`).
+Note that, to spawn `async` blocks, the `tokio::run_async` function should be used (instead of `tokio::run`).
 
 ## Going deeper
 
@@ -101,14 +91,9 @@ fn main() {
 }
 ```
 
-In this example, `incoming` is a stream of accepted `TcpStream` values. We are
-using `async` / `await` to iterate the stream. Currently, there is only syntax
-for awaiting on a single value (future), so we use the `next` combinator to get
-a future of the next value in the stream. This lets us iterate the stream with
-`while` syntax.
+In this example, `incoming` is a stream of accepted `TcpStream` values. We are using `async` / `await` to iterate the stream. Currently, there is only syntax for awaiting on a single value (future), so we use the `next` combinator to get a future of the next value in the stream. This lets us iterate the stream with `while` syntax.
 
-Once we get the stream, it is passed to the `handle` function to process. Lets
-see how that is implemented.
+Once we get the stream, it is passed to the `handle` function to process. Lets see how that is implemented.
 
 ```rust,ignore
 fn handle(mut stream: TcpStream) {
@@ -128,40 +113,23 @@ fn handle(mut stream: TcpStream) {
 }
 ```
 
-Just like `run_async`, there is a `spawn_async` function to spawn async blocks
-as tasks.
+Just like `run_async`, there is a `spawn_async` function to spawn async blocks as tasks.
 
-Then, to perform the echo logic, we read from the socket into a buffer and
-write the data back to the same socket. Because we are using `async` / `await`,
-we can use an array that looks stack allocated (it actually ends up in the
-heap).
+Then, to perform the echo logic, we read from the socket into a buffer and write the data back to the same socket. Because we are using `async` / `await`, we can use an array that looks stack allocated (it actually ends up in the heap).
 
-Note that `TcpStream` has `read_async` and `write_all_async` functions. These
-functions perform the same logic as the synchronous equivalents that exist on the
-`Read` and `Write` traits in `std`. The difference, they return futures that can
-be awaited on.
+Note that `TcpStream` has `read_async` and `write_all_async` functions. These functions perform the same logic as the synchronous equivalents that exist on the `Read` and `Write` traits in `std`. The difference, they return futures that can be awaited on.
 
-The `*_async` functions are defined in the `tokio-async-await` crate by using
-extension traits. These traits got imported with the `use tokio::prelude::*;`
-line.
+The `*_async` functions are defined in the `tokio-async-await` crate by using extension traits. These traits got imported with the `use tokio::prelude::*;` line.
 
-This is just a start, check the [examples] directory in the repository for more.
-There even is one using [hyper].
+This is just a start, check the [examples] directory in the repository for more. There even is one using [hyper].
 
 ## Some notes
 
-First, the `tokio-async-await` crate only provides compatibility for `async` /
-`await` syntax. It does **not** provide support for the `futures` 0.3 crate. It
-is expected that users continue using futures 0.1 to remain compatible with
-Tokio.
+First, the `tokio-async-await` crate only provides compatibility for `async` / `await` syntax. It does **not** provide support for the `futures` 0.3 crate. It is expected that users continue using futures 0.1 to remain compatible with Tokio.
 
-To make this work, the `tokio-async-await` crate defines its own `await!` macro.
-This macro is a shim on top of the one provided by `std` that enables waiting
-for `futures` 0.1 futures. This is how the compatibility layer is able to stay
-**lightweight** and **boilerplate** free.
+To make this work, the `tokio-async-await` crate defines its own `await!` macro. This macro is a shim on top of the one provided by `std` that enables waiting for `futures` 0.1 futures. This is how the compatibility layer is able to stay **lightweight** and **boilerplate** free.
 
-This is just a start. The `async` / `await` support will continue to evolve and
-improve over time, but this is enough to get everyone going!
+This is just a start. The `async` / `await` support will continue to evolve and improve over time, but this is enough to get everyone going!
 
 And with that, have a great week!
 

--- a/content/blog/2018-08-incremental-improvements.md
+++ b/content/blog/2018-08-incremental-improvements.md
@@ -6,72 +6,47 @@ menu = "blog"
 weight = 992
 +++
 
-It took a bit longer than I had initially hoped (as it always does), but a new
-Tokio version has been released. This release includes, among other features, a
-new [set of APIs][fs] that allow performing filesystem operations from an
-asynchronous context, concurrency improvements, timer improvements, and more
-(including bug fixes, so be sure to update!).
+It took a bit longer than I had initially hoped (as it always does), but a new Tokio version has been released. This release includes, among other features, a new [set of APIs][fs] that allow performing filesystem operations from an asynchronous context, concurrency improvements, timer improvements, and more (including bug fixes, so be sure to update!).
 
-It has been a little bit since the last post. There haven't been any big
-feature releases, but that doesn't mean that we have been idle. New crates have
-been released with many incremental improvements over the past few months. Many
-of these improvements have been contributed by the community, so I thought a
-little highlight was in order.
+It has been a little bit since the last post. There haven't been any big feature releases, but that doesn't mean that we have been idle. New crates have been released with many incremental improvements over the past few months. Many of these improvements have been contributed by the community, so I thought a little highlight was in order.
 
 ## Filesystem APIs
 
-The initial release of `tokio-fs` was more of a stub than a full implementation.
-It only included basic file system operations.
+The initial release of `tokio-fs` was more of a stub than a full implementation. It only included basic file system operations.
 
-The latest release includes [non-blocking versions][fs] for most file system
-APIs. This amazing work was contributed mostly by [@griff] in an [epic PR][pr]
-and [@lnicola] in a series of smaller PRs, but many others participated to help
-review and improve the crate.
+The latest release includes [non-blocking versions][fs] for most file system APIs. This amazing work was contributed mostly by [@griff] in an [epic PR][pr] and [@lnicola] in a series of smaller PRs, but many others participated to help review and improve the crate.
 
-Thanks goes to: [@dekellum], [@matsadler], [@debris], [@mati865], [@lovebug356],
-[@bryanburgers], [@shepmaster].
+Thanks goes to: [@dekellum], [@matsadler], [@debris], [@mati865], [@lovebug356], [@bryanburgers], [@shepmaster].
 
 [fs]: https://docs.rs/tokio/0.1.8/tokio/fs/index.html
 [pr]: https://github.com/tokio-rs/tokio/pull/494
 
 ## Concurrency improvements
 
-Over the past couple months, [@stjepang] has been chugging along improving the
-concurrency related bits of Tokio. Some highlights:
+Over the past couple months, [@stjepang] has been chugging along improving the concurrency related bits of Tokio. Some highlights:
 
 * [#459] - Fix a race in thread wakeup
 * [#470] - Improve worker spinning
 * [#517] - Improve scalability of a RW Lock used in the reactor.
 * [#534] - Improve the stealing part of the work-stealing runtime.
 
-We also had a good chat while he was in town for Rustconf, and I'm excited for
-his work that is yet to come.
+We also had a good chat while he was in town for Rustconf, and I'm excited for his work that is yet to come.
 
 And of course, thanks for all the [crossbeam] work. Tokio heavily depends on it.
 
 ## `current_thread::Runtime`
 
-The `current_thread::Runtime` has also received a number of incremental
-improvements since it was initially introduced by [@vorner] and [@kpp].
+The `current_thread::Runtime` has also received a number of incremental improvements since it was initially introduced by [@vorner] and [@kpp].
 
-[@sdroege] added a `Handle` that allows spawning tasks onto the runtime from
-other threads ([#340]). This is implemented using a channel to send the task to the
-runtime thread (a similar strategy that `tokio-core` used).
+[@sdroege] added a `Handle` that allows spawning tasks onto the runtime from other threads ([#340]). This is implemented using a channel to send the task to the runtime thread (a similar strategy that `tokio-core` used).
 
-And [@jonhoo] implemented a `block_on_all` function ([#477]) and fixed a bug
-with tracking the number of active futures and coordinating shutdown ([#478])
+And [@jonhoo] implemented a `block_on_all` function ([#477]) and fixed a bug with tracking the number of active futures and coordinating shutdown ([#478])
 
 ## Timer improvements
 
-`tokio::timer` does get a new feature: [`DelayQueue`]. This type allows the user
-to store values that get returned back after some period of time. This is useful
-for supporting more complex time related cases.
+`tokio::timer` does get a new feature: [`DelayQueue`]. This type allows the user to store values that get returned back after some period of time. This is useful for supporting more complex time related cases.
 
-Lets' take a cache as an example. The goal of a cache is to hold values
-associated with a key for a certain amount of time. After the time elapses, the
-value is dropped. It has always been possible to implement this with
-[`tokio::timer::Delay`][Delay], but is a bit challenging. When the cache has many
-entries, all of them must be scanned to check if they need to be dropped.
+Lets' take a cache as an example. The goal of a cache is to hold values associated with a key for a certain amount of time. After the time elapses, the value is dropped. It has always been possible to implement this with [`tokio::timer::Delay`][Delay], but is a bit challenging. When the cache has many entries, all of them must be scanned to check if they need to be dropped.
 
 With [`DelayQueue`], the implementation becomes more efficient:
 
@@ -128,10 +103,7 @@ impl Cache {
 
 ## Many other small improvements
 
-Besides what has been listed above, Tokio has received many small improvements
-and bug fixes across most of the crates. These have been provided by our amazing
-community.  I'm hoping that over time, more and more people will join the effort
-of building Tokio and help it continue to evolve.
+Besides what has been listed above, Tokio has received many small improvements and bug fixes across most of the crates. These have been provided by our amazing community.  I'm hoping that over time, more and more people will join the effort of building Tokio and help it continue to evolve.
 
 So, a big thanks to [all of you have have contributed][contrib] to Tokio to date.
 

--- a/content/blog/2018-10-doc-blitz.md
+++ b/content/blog/2018-10-doc-blitz.md
@@ -6,26 +6,17 @@ menu = "blog"
 weight = 990
 +++
 
-In the past, there has been reoccurring feedback that Tokio is hard to
-understand. I believe a lack of good documentation plays a significant part.
-It's time to fix this problem.
+In the past, there has been reoccurring feedback that Tokio is hard to understand. I believe a lack of good documentation plays a significant part. It's time to fix this problem.
 
-And because Tokio is open source, it is on us (the community) to make this
-happen! 👏
+And because Tokio is open source, it is on us (the community) to make this happen! 👏
 
-But don't worry, this isn't an aimless request to contribute documentation. It
-does, however, require participation. There are ways to get involved at any
-level of prior Tokio experience.
+But don't worry, this isn't an aimless request to contribute documentation. It does, however, require participation. There are ways to get involved at any level of prior Tokio experience.
 
 ## The Tokio documentation push
 
-Here is the plan. A temporary repository
-[`doc-push`](http://github.com/tokio-rs/doc-push) has been setup, and that is
-where the documentation effort will be coordinated. The README has steps on how
-to get started. Roughly, the process will be:
+Here is the plan. A temporary repository [`doc-push`](http://github.com/tokio-rs/doc-push) has been setup, and that is where the documentation effort will be coordinated. The README has steps on how to get started. Roughly, the process will be:
 
-1) Read the existing documentation, tracking parts that are confusing or leave
-questions unanswered.
+1) Read the existing documentation, tracking parts that are confusing or leave questions unanswered.
 
 2) Open an issue on the doc-push repository to report the confusion.
 
@@ -37,32 +28,19 @@ Where "fix the issue" is fix an existing guide or write a new guide.
 
 ## Writing new guides
 
-To get the effort of writing new guides bootstrapped, the doc-push repository
-has been seeded with an [outline] representing my best guess of how the guides
-should be structured.
+To get the effort of writing new guides bootstrapped, the doc-push repository has been seeded with an [outline] representing my best guess of how the guides should be structured.
 
-Anyone can volunteer to write a page from this outline. Just submit a PR adding
-your Github handle next to the page. For example, if you wanted to volunteer to
-write a guide on timeouts, you would submit a PR updating the
-[section](https://github.com/tokio-rs/doc-push/blob/master/outline/tracking-time.md#timeouts),
-changing **Status: Unassigned** to **Status: Assigned (@myname)**.
+Anyone can volunteer to write a page from this outline. Just submit a PR adding your Github handle next to the page. For example, if you wanted to volunteer to write a guide on timeouts, you would submit a PR updating the [section](https://github.com/tokio-rs/doc-push/blob/master/outline/tracking-time.md#timeouts), changing **Status: Unassigned** to **Status: Assigned (@myname)**.
 
-Also, feedback and suggestions on the outline structure is greatly appreciated.
-Please open issues and PRs agains the outline.
+Also, feedback and suggestions on the outline structure is greatly appreciated. Please open issues and PRs agains the outline.
 
-There is also a new [Gitter] channel dedicated to the doc push. If you want to
-get involved, but need some guidance. Join the channel and ping us.  Perhaps you
-want to try to write a guide, but don't quite feel up to the task yet. Ping us,
-and we will help you through it.
+There is also a new [Gitter] channel dedicated to the doc push. If you want to get involved, but need some guidance. Join the channel and ping us.  Perhaps you want to try to write a guide, but don't quite feel up to the task yet. Ping us, and we will help you through it.
 
 ## An experiment
 
-The doc push is an experiment. I don't know how it will go, but I am
-hopeful that it will be successful.
+The doc push is an experiment. I don't know how it will go, but I am hopeful that it will be successful.
 
-It is also an iterative effort. Once a pass at improving the guides happens, we
-need to go back to step 1) and have new comers try to learn Tokio using the new
-documentation. This will expose new gaps which will need to be addressed.
+It is also an iterative effort. Once a pass at improving the guides happens, we need to go back to step 1) and have new comers try to learn Tokio using the new documentation. This will expose new gaps which will need to be addressed.
 
 ## FAQ
 
@@ -70,8 +48,7 @@ documentation. This will expose new gaps which will need to be addressed.
 
 First, this isn't a question.
 
-Second, great! You are who we want to get involved. We need fresh eyes to go
-over the guides and report issues that they hit.
+Second, great! You are who we want to get involved. We need fresh eyes to go over the guides and report issues that they hit.
 
 Things that you can do:
 
@@ -83,18 +60,13 @@ Things that you can do:
 
 Still not a question!
 
-You know what *they* say: "teaching is the best way to learn". This is a great
-opportunity to learn Tokio. First, there are some outlines to get you started.
-These outlines will probably result in you having questions or need some
-pointers. Perhaps you need to learn the topic first before writing the guide!
+You know what *they* say: "teaching is the best way to learn". This is a great opportunity to learn Tokio. First, there are some outlines to get you started. These outlines will probably result in you having questions or need some pointers. Perhaps you need to learn the topic first before writing the guide!
 
-We are in the [Gitter] channel waiting eagerly to help you along. We will help
-you learn what you need to. In exchange, you will contribute a guide 😊.
+We are in the [Gitter] channel waiting eagerly to help you along. We will help you learn what you need to. In exchange, you will contribute a guide 😊.
 
 ## tl;dr
 
-This is your opportunity to help make Tokio easier to learn. It won't happen
-without volunteering for the doc push. In short:
+This is your opportunity to help make Tokio easier to learn. It won't happen without volunteering for the doc push. In short:
 
 1) Join the [Gitter].
 

--- a/content/community.md
+++ b/content/community.md
@@ -3,19 +3,12 @@ title = "The Tokio Community"
 description = "Get help, discuss problems, and join the fun"
 +++
 
-The Tokio community is most readily found on
-[its gitter channel](https://gitter.im/tokio-rs/tokio), where you're welcome to
-ask questions, report problems, or pitch ideas.
+The Tokio community is most readily found on [its gitter channel](https://gitter.im/tokio-rs/tokio), where you're welcome to ask questions, report problems, or pitch ideas.
 
 Github is used for tracking issues.
 
-We also have an issue tracker on the main [Tokio
-repository](https://github.com/tokio-rs/tokio/issues)
+We also have an issue tracker on the main [Tokio repository](https://github.com/tokio-rs/tokio/issues)
 
-If you're a Tokio user, you're highly encouraged to keep an eye on these issues
-and jump in on the discussions, to help us understand how design tradeoffs might
-affect you.
+If you're a Tokio user, you're highly encouraged to keep an eye on these issues and jump in on the discussions, to help us understand how design tradeoffs might affect you.
 
-These repositories also contain milestones for upcoming *major* releases, which
-are currently used to track breaking changes that might be considered for the
-next major release.
+These repositories also contain milestones for upcoming *major* releases, which are currently used to track breaking changes that might be considered for the next major release.

--- a/content/community/third-party.md
+++ b/content/community/third-party.md
@@ -3,33 +3,25 @@ title = "Third-party crates"
 description = ""
 +++
 
-Currently the [`futures`], [`tokio-core`], [`tokio-service`], and [`tokio-proto`] crates provide
-the foundation for the Tokio ecosystem. There's a growing set of crates outside
-of Tokio itself, however, filling in more functionality!
+Currently the [`futures`], [`tokio-core`], [`tokio-service`], and [`tokio-proto`] crates provide the foundation for the Tokio ecosystem. There's a growing set of crates outside of Tokio itself, however, filling in more functionality!
 
 * [`tokio-curl`] is an HTTP client library backed by the libcurl C library.
-* [`tokio-timer`] is a timer library providing finer-grained control over timers
-  and helpful timeout facilities over the types in [`tokio-core`].
+* [`tokio-timer`] is a timer library providing finer-grained control over timers and helpful timeout facilities over the types in [`tokio-core`].
 * [`tokio-tls`] is a library for TLS streams backed by [`native-tls`].
 * [`tokio-openssl`] is similar to [`tokio-tls`] but hardwired to OpenSSL.
-* [`tokio-uds`] is a Unix library for supporting Unix Domain Sockets in the same
-  way that `tokio_core::net` works with TCP sockets
+* [`tokio-uds`] is a Unix library for supporting Unix Domain Sockets in the same way that `tokio_core::net` works with TCP sockets
 * [`tokio-inotify`] maps inotify file descriptors to a `Stream`.
 * [`tokio-signal`] maps Unix signals to a `Stream`.
 * [`tokio-serial`] is a (Unix-only) serial port I/O library.
-* [`tokio-process`] enables asynchronous process managment, both for child
-  processes exiting as well as I/O pipes to children.
-* [`trust-dns`] is an asynchronous DNS client and server, supporting features
-  like DNSSec as well
-* [`capnproto-rust`] is an implementation of Cap'n Proto for Rust which has the
-  ability to work with futures as well
+* [`tokio-process`] enables asynchronous process managment, both for child processes exiting as well as I/O pipes to children.
+* [`trust-dns`] is an asynchronous DNS client and server, supporting features like DNSSec as well
+* [`capnproto-rust`] is an implementation of Cap'n Proto for Rust which has the ability to work with futures as well
 * [`tk-sendfile`] allows using the `sendfile` syscall with Tokio
 * [`tokio-postgres`] is an asynchronous PostgreSQL driver
 * [`tokio-retry`] provides extensible asynchronous retry behaviours
 * [`couchbase`] is an asynchronous driver for Couchbase, exposing Futures and Streams as first class response types.
 
-If you've got your own crate or know of others that should be present on this
-list, please feel free to send a PR!
+If you've got your own crate or know of others that should be present on this list, please feel free to send a PR!
 
 [`futures`]: https://github.com/alexcrichton/futures-rs
 [`tokio-core`]: https://github.com/tokio-rs/tokio-core
@@ -53,4 +45,3 @@ list, please feel free to send a PR!
 [`thrussh`]: https://crates.io/crates/thrussh
 [`tokio-retry`]: https://github.com/srijs/rust-tokio-retry
 [`couchbase`]: https://crates.io/crates/couchbase
-

--- a/content/docs/futures-streams-sinks/futures.md
+++ b/content/docs/futures-streams-sinks/futures.md
@@ -6,7 +6,6 @@ menu:
     parent: futures_streams_sinks
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/futures-streams-sinks/overview.md
+++ b/content/docs/futures-streams-sinks/overview.md
@@ -6,7 +6,6 @@ menu:
     parent: futures_streams_sinks
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/futures-streams-sinks/putting-it-together.md
+++ b/content/docs/futures-streams-sinks/putting-it-together.md
@@ -6,7 +6,6 @@ menu:
     parent: futures_streams_sinks
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/futures-streams-sinks/sinks.md
+++ b/content/docs/futures-streams-sinks/sinks.md
@@ -6,7 +6,6 @@ menu:
     parent: futures_streams_sinks
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/futures-streams-sinks/streams.md
+++ b/content/docs/futures-streams-sinks/streams.md
@@ -6,7 +6,6 @@ menu:
     parent: futures_streams_sinks
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -6,43 +6,27 @@ menu:
     parent: getting_started
 ---
 
-Futures, hinted at earlier in the guide, are the building block used to manage
-asynchronous logic. They are the underlying asynchronous abstraction used by
-Tokio.
+Futures, hinted at earlier in the guide, are the building block used to manage asynchronous logic. They are the underlying asynchronous abstraction used by Tokio.
 
-The future implementation is provided by the [`futures`] crate. However, for
-convenience, Tokio re-exports a number of the types.
+The future implementation is provided by the [`futures`] crate. However, for convenience, Tokio re-exports a number of the types.
 
 # What Are Futures?
 
-A future is a value that represents the completion of an asynchronous
-computation. Usually, the future _completes_ due to an event that happens
-elsewhere in the system. While we’ve been looking at things from the perspective
-of basic I/O, you can use a future to represent a wide range of events, e.g.:
+A future is a value that represents the completion of an asynchronous computation. Usually, the future _completes_ due to an event that happens elsewhere in the system. While we’ve been looking at things from the perspective of basic I/O, you can use a future to represent a wide range of events, e.g.:
 
-* **A database query** that’s executing in a thread pool. When the query
-  finishes, the future is completed, and its value is the result of the query.
+* **A database query** that’s executing in a thread pool. When the query finishes, the future is completed, and its value is the result of the query.
 
-* **An RPC invocation** to a server. When the server replies, the future is
-  completed, and its value is the server’s response.
+* **An RPC invocation** to a server. When the server replies, the future is completed, and its value is the server’s response.
 
-* **A timeout**. When time is up, the future is completed, and its value is
-  `()`.
+* **A timeout**. When time is up, the future is completed, and its value is `()`.
 
-* **A long-running CPU-intensive task**, running on a thread pool. When the task
-  finishes, the future is completed, and its value is the return value of the
-  task.
+* **A long-running CPU-intensive task**, running on a thread pool. When the task finishes, the future is completed, and its value is the return value of the task.
 
-* **Reading bytes from a socket**. When the bytes are ready, the future is
-  completed – and depending on the buffering strategy, the bytes might be
-  returned directly, or written as a side-effect into some existing buffer.
+* **Reading bytes from a socket**. When the bytes are ready, the future is completed – and depending on the buffering strategy, the bytes might be returned directly, or written as a side-effect into some existing buffer.
 
-The entire point of the future abstraction is to allow asynchronous functions,
-i.e., functions that cannot immediately return a value, to be able to return
-**something**.
+The entire point of the future abstraction is to allow asynchronous functions, i.e., functions that cannot immediately return a value, to be able to return **something**.
 
-For example, an asynchronous HTTP client could provide a `get` function that
-looks like this:
+For example, an asynchronous HTTP client could provide a `get` function that looks like this:
 
 ```rust,ignore
 pub fn get(&self, uri: &str) -> ResponseFuture { ... }
@@ -54,11 +38,7 @@ Then, the user of the library would use the function as so:
 let response_future = client.get("https://www.example.com");
 ```
 
-Now, the `response_future` isn't the actual response. It is a future that will
-complete once the response is received. However, since the caller has a concrete
-**thing** (the future), they can start to use it. For example, they may chain
-computations to perform once the response is received or they might pass the
-future to a function.
+Now, the `response_future` isn't the actual response. It is a future that will complete once the response is received. However, since the caller has a concrete **thing** (the future), they can start to use it. For example, they may chain computations to perform once the response is received or they might pass the future to a function.
 
 ```rust,ignore
 let response_is_ok = response_future
@@ -69,27 +49,17 @@ let response_is_ok = response_future
 track_response_success(response_is_ok);
 ```
 
-All of those actions taken with the future don't immediately perform any work.
-They cannot because they don't have the actual HTTP response. Instead, they
-define the work to be done when the response future completes.
+All of those actions taken with the future don't immediately perform any work. They cannot because they don't have the actual HTTP response. Instead, they define the work to be done when the response future completes.
 
-Both the [`futures`] crate and Tokio come with a collection of combinator
-functions that can be used to work with futures.
+Both the [`futures`] crate and Tokio come with a collection of combinator functions that can be used to work with futures.
 
 # Implementing `Future`
 
-Implementing the `Future` is pretty common when using Tokio, so it is important
-to be comfortable with it.
+Implementing the `Future` is pretty common when using Tokio, so it is important to be comfortable with it.
 
-As discussed in the previous section, Rust futures are poll based. This is a
-unique aspect of the Rust future library. Most future libraries for other
-programming languages use a push based model where callbacks are supplied to the
-future and the computation invokes the callback immediately with the computation
-result.
+As discussed in the previous section, Rust futures are poll based. This is a unique aspect of the Rust future library. Most future libraries for other programming languages use a push based model where callbacks are supplied to the future and the computation invokes the callback immediately with the computation result.
 
-Using a poll based model offers [many advantages], including being a zero cost
-abstraction, i.e., using Rust futures has no added overhead compared to writing
-the asynchronous code by hand.
+Using a poll based model offers [many advantages], including being a zero cost abstraction, i.e., using Rust futures has no added overhead compared to writing the asynchronous code by hand.
 
 [many advantages]: https://aturon.github.io/blog/2016/09/07/futures-design/
 
@@ -108,13 +78,9 @@ trait Future {
 }
 ```
 
-Usually, when you implement a `Future`, you will be defining a computation that
-is a composition of sub (or inner) futures. In this case, the future implementation tries
-to call the inner future(s) and returns `NotReady` if the inner futures are not
-ready.
+Usually, when you implement a `Future`, you will be defining a computation that is a composition of sub (or inner) futures. In this case, the future implementation tries to call the inner future(s) and returns `NotReady` if the inner futures are not ready.
 
-The following example is a future that is composed of another future that
-returns a `usize` and will double that value:
+The following example is a future that is composed of another future that returns a `usize` and will double that value:
 
 ```rust
 # #![deny(deprecated)]
@@ -144,15 +110,9 @@ where T: Future<Item = usize>
 # pub fn main() {}
 ```
 
-When the `Doubler` future is polled, it polls its inner future. If the inner
-future is not ready, the `Doubler` future returns `NotReady`. If the inner
-future is ready, then the `Doubler` future doubles the return value and returns
-`Ready`.
+When the `Doubler` future is polled, it polls its inner future. If the inner future is not ready, the `Doubler` future returns `NotReady`. If the inner future is ready, then the `Doubler` future doubles the return value and returns `Ready`.
 
-Because the matching pattern above is common, the [`futures`] crate provides a
-macro: `try_ready!`. It is similar to `try!` or `?`, but it also returns on
-`NotReady`. The above `poll` function can be rewritten using `try_ready!` as
-follows:
+Because the matching pattern above is common, the [`futures`] crate provides a macro: `try_ready!`. It is similar to `try!` or `?`, but it also returns on `NotReady`. The above `poll` function can be rewritten using `try_ready!` as follows:
 
 ```rust
 # #![deny(deprecated)]
@@ -179,36 +139,19 @@ fn poll(&mut self) -> Result<Async<usize>, T::Error> {
 
 # Returning `NotReady`
 
-The last section handwaved a bit and said that once a Future transitioned to the
-ready state, the executor is notified. This enables the executor to be efficient
-in scheduling tasks.
+The last section handwaved a bit and said that once a Future transitioned to the ready state, the executor is notified. This enables the executor to be efficient in scheduling tasks.
 
-When a function returns Async::NotReady, it signals that it is currently not in
-a ready state and is unable to complete the operation. It is critical that the
-executor is notified when the state transitions to "ready". Otherwise, the task
-will hang infinitely, never getting run again.
+When a function returns Async::NotReady, it signals that it is currently not in a ready state and is unable to complete the operation. It is critical that the executor is notified when the state transitions to "ready". Otherwise, the task will hang infinitely, never getting run again.
 
-For most future implementations, this is done transitively. When a future
-implementation is a combination of sub futures, the outer future only returns
-`NotReady` when at least one inner future returned `NotReady`. Thus, the outer
-future will transition to a ready state once the inner future transitions to a
-ready state. In this case, the `NotReady` contract is already satisfied as the
-inner future will notify the executor when it becomes ready.
+For most future implementations, this is done transitively. When a future implementation is a combination of sub futures, the outer future only returns `NotReady` when at least one inner future returned `NotReady`. Thus, the outer future will transition to a ready state once the inner future transitions to a ready state. In this case, the `NotReady` contract is already satisfied as the inner future will notify the executor when it becomes ready.
 
-Innermost futures, sometimes called "resources", are the ones responsible for
-notifying the executor. This is done by calling [`notify`] on the task returned
-by [`task::current()`].
+Innermost futures, sometimes called "resources", are the ones responsible for notifying the executor. This is done by calling [`notify`] on the task returned by [`task::current()`].
 
-We will be exploring implementing resources and the task system in more depth in
-a later section. The key take away here is **do not return `NotReady` unless you
-got `NotReady` from an inner future**.
+We will be exploring implementing resources and the task system in more depth in a later section. The key take away here is **do not return `NotReady` unless you got `NotReady` from an inner future**.
 
 # A More Complicated Future
 
-Let's look at a slightly more complicated future implementation. In this case, we
-will implement a future that takes a host name, does DNS resolution, then
-establishes a connection to the remote host. We assume a `resolve` function
-exists that looks like this:
+Let's look at a slightly more complicated future implementation. In this case, we will implement a future that takes a host name, does DNS resolution, then establishes a connection to the remote host. We assume a `resolve` function exists that looks like this:
 
 ```rust,ignore
 pub fn resolve(host: &str) -> ResolveFuture;
@@ -224,8 +167,7 @@ The steps to implement the future are:
 4. Call `ConnectFuture::poll` until it returns the `TcpStream`.
 5. Complete the outer future with the `TcpStream`.
 
-We will use an `enum` to track the state of the future as it advances through
-these steps.
+We will use an `enum` to track the state of the future as it advances through these steps.
 
 ```rust
 # extern crate tokio;
@@ -309,17 +251,14 @@ impl Future for ResolveAndConnect {
 # pub fn main() {}
 ```
 
-This illustrates how `Future` implementations are state machines. This future
-can be in either of two states:
+This illustrates how `Future` implementations are state machines. This future can be in either of two states:
 
 1. Resolving
 2. Connecting
 
-Each time `poll` is called, we try to advance the state machine to the next
-state.
+Each time `poll` is called, we try to advance the state machine to the next state.
 
-Now, the future is basically a re-implementation of the combinator [`AndThen`], so we would
-probably just use that combinator.
+Now, the future is basically a re-implementation of the combinator [`AndThen`], so we would probably just use that combinator.
 
 ```rust
 # #![deny(deprecated)]

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -6,15 +6,9 @@ menu:
     parent: getting_started
 ---
 
-To kick off our tour of Tokio, we will start with the obligatory "hello world"
-example. This program will create a TCP stream and write "hello, world!" to the stream.
-The difference between this and a Rust program that writes to a TCP stream without Tokio
-is that this program won't block program execution when the stream is created or when
-our "hello, world!" message is written to the stream.
+To kick off our tour of Tokio, we will start with the obligatory "hello world" example. This program will create a TCP stream and write "hello, world!" to the stream. The difference between this and a Rust program that writes to a TCP stream without Tokio is that this program won't block program execution when the stream is created or when our "hello, world!" message is written to the stream.
 
-Before we begin you should have a very basic understanding of how TCP streams work. Having
-an understanding of Rust’s [standard library implementation](https://doc.rust-lang.org/std/net/struct.TcpStream.html)
-is also helpful.
+Before we begin you should have a very basic understanding of how TCP streams work. Having an understanding of Rust’s [standard library implementation](https://doc.rust-lang.org/std/net/struct.TcpStream.html) is also helpful.
 
 Let's get started.
 
@@ -46,8 +40,7 @@ use tokio::prelude::*;
 
 # Creating the stream
 
-The first step is to create the `TcpStream`. We use the `TcpStream` implementation provided
-by Tokio.
+The first step is to create the `TcpStream`. We use the `TcpStream` implementation provided by Tokio.
 
 ```rust
 # #![deny(deprecated)]
@@ -63,8 +56,7 @@ fn main() {
 }
 ```
 
-Next, we define the `client` task. This asynchronous task will create the stream
-and then yield the stream once it's been created for additional processing.
+Next, we define the `client` task. This asynchronous task will create the stream and then yield the stream once it's been created for additional processing.
 
 ```rust
 # #![deny(deprecated)]
@@ -91,34 +83,17 @@ let hello_world = TcpStream::connect(&addr).and_then(|stream| {
 # }
 ```
 
-The call to `TcpStream::connect` returns a [`Future`] of the created TCP stream.
-We'll learn more about [`Futures`] later in the guide, but for now you can think of
-a [`Future`] as a value that represents something that will eventually happen in the
-future (in this case the stream will be created). This means that `TcpStream::connect` does
-not wait for the stream to be created before it returns. Rather it returns immediately
-with a value representing the work of creating a TCP stream. We'll see down below when this work
-_actually_ gets executed.
+The call to `TcpStream::connect` returns a [`Future`] of the created TCP stream. We'll learn more about [`Futures`] later in the guide, but for now you can think of a [`Future`] as a value that represents something that will eventually happen in the future (in this case the stream will be created). This means that `TcpStream::connect` does not wait for the stream to be created before it returns. Rather it returns immediately with a value representing the work of creating a TCP stream. We'll see down below when this work _actually_ gets executed.
 
-The `and_then` method yields the stream once it has been created. `and_then` is an
-example of a combinator function that defines how asynchronous work will be processed.
+The `and_then` method yields the stream once it has been created. `and_then` is an example of a combinator function that defines how asynchronous work will be processed.
 
-Each combinator function takes ownership of necessary state as well as the
-callback to perform and returns a new `Future` that has the additional "step"
-sequenced. A `Future` is a value representing some computation that will complete at
-some point in the future.
+Each combinator function takes ownership of necessary state as well as the callback to perform and returns a new `Future` that has the additional "step" sequenced. A `Future` is a value representing some computation that will complete at some point in the future.
 
-It's worth reiterating that returned futures are lazy, i.e., no work is performed when
-calling the combinator. Instead, once all the asynchronous steps are sequenced, the
-final `Future` (representing the entire task) is "spawned" (i.e., run). This is when
-the work that was previously defined starts getting run. In other words, the code
-we've written so far does not actually create a TCP stream.
+It's worth reiterating that returned futures are lazy, i.e., no work is performed when calling the combinator. Instead, once all the asynchronous steps are sequenced, the final `Future` (representing the entire task) is "spawned" (i.e., run). This is when the work that was previously defined starts getting run. In other words, the code we've written so far does not actually create a TCP stream.
 
-We will be digging more into futures (and the related concepts of streams and sinks)
-later on.
+We will be digging more into futures (and the related concepts of streams and sinks) later on.
 
-It's also important to note that we've called `map_err` to convert whatever error
-we may have gotten to `()` before we can actually run our future. This ensures that
-we acknowledge errors.
+It's also important to note that we've called `map_err` to convert whatever error we may have gotten to `()` before we can actually run our future. This ensures that we acknowledge errors.
 
 Next, we will process the stream.
 
@@ -149,25 +124,15 @@ let client = TcpStream::connect(&addr).and_then(|stream| {
 # }
 ```
 
-The [`io::write_all`] function takes ownership of `stream`, returning a
-[`Future`] that completes once the entire message has been written to the
-stream. `then` is used to sequence a step that gets run once the write has
-completed. In our example, we just write a message to `STDOUT` indicating that
-the write has completed.
+The [`io::write_all`] function takes ownership of `stream`, returning a [`Future`] that completes once the entire message has been written to the stream. `then` is used to sequence a step that gets run once the write has completed. In our example, we just write a message to `STDOUT` indicating that the write has completed.
 
-Note that `result` is a `Result` that contains the original stream. This allows us
-to sequence additional reads or writes to the same stream. However, we have
-nothing more to do, so we just drop the stream, which automatically closes it.
+Note that `result` is a `Result` that contains the original stream. This allows us to sequence additional reads or writes to the same stream. However, we have nothing more to do, so we just drop the stream, which automatically closes it.
 
 # Running the client task
 
-So far we have a `Future` representing the work to be done by our program, but we
-have not actually run it. We need a way to "spawn" that work. We need an executor.
+So far we have a `Future` representing the work to be done by our program, but we have not actually run it. We need a way to "spawn" that work. We need an executor.
 
-Executors are responsible for scheduling asynchronous tasks, driving them to
-completion. There are a number of executor implementations to choose from, each have
-different pros and cons. In this example, we will use the default executor of the
-[Tokio runtime][rt].
+Executors are responsible for scheduling asynchronous tasks, driving them to completion. There are a number of executor implementations to choose from, each have different pros and cons. In this example, we will use the default executor of the [Tokio runtime][rt].
 
 ```rust
 # #![deny(deprecated)]
@@ -184,19 +149,15 @@ println!("Stream has been created and written to.");
 # }
 ```
 
-`tokio::run` starts the runtime, blocking the current thread until all spawned tasks
-have completed and all resources (like files and sockets) have been dropped.
+`tokio::run` starts the runtime, blocking the current thread until all spawned tasks have completed and all resources (like files and sockets) have been dropped.
 
-So far, we only have a single task running on the executor, so the `client` task
-is the only one blocking `run` from returning. Once `run` has returned we can be sure
-that our Future has been run to completion.
+So far, we only have a single task running on the executor, so the `client` task is the only one blocking `run` from returning. Once `run` has returned we can be sure that our Future has been run to completion.
 
 You can find the full example [here][full-code].
 
 # Next steps
 
-We've only dipped our toes into Tokio and its asynchronous model. The next page in
-the guide, will start digging deeper into the Tokio runtime model.
+We've only dipped our toes into Tokio and its asynchronous model. The next page in the guide, will start digging deeper into the Tokio runtime model.
 
 [`Future`]: {{< api-url "futures" >}}/future/trait.Future.html
 [rt]: {{< api-url "tokio" >}}/runtime/index.html

--- a/content/docs/getting-started/io.md
+++ b/content/docs/getting-started/io.md
@@ -6,23 +6,15 @@ menu:
     parent: getting_started
 ---
 
-The [`tokio`] crate comes with TCP and UDP networking types. Unlike the types in
-`std`, Tokio's networking types are based on the poll model and will notify the
-task executors when their readiness states change (data is received and write
-buffers are flushed). In the [`tokio::net`] module you'll find types like
-[`TcpListener`], [`TcpStream`], and [`UdpSocket`].
+The [`tokio`] crate comes with TCP and UDP networking types. Unlike the types in `std`, Tokio's networking types are based on the poll model and will notify the task executors when their readiness states change (data is received and write buffers are flushed). In the [`tokio::net`] module you'll find types like [`TcpListener`], [`TcpStream`], and [`UdpSocket`].
 
-All of these types provide both a future API as well as a poll
-API.
+All of these types provide both a future API as well as a poll API.
 
-The Tokio net types are powered by a [Mio] based reactor that, by default, is
-started up lazily on a background thread. See [reactor] documentation for more
-details.
+The Tokio net types are powered by a [Mio] based reactor that, by default, is started up lazily on a background thread. See [reactor] documentation for more details.
 
 # Using the Future API
 
-We've already seen some of this earlier in the guide with the [`incoming`]
-function as well as the helpers found in [`tokio_io::io`].
+We've already seen some of this earlier in the guide with the [`incoming`] function as well as the helpers found in [`tokio_io::io`].
 
 These helpers include:
 
@@ -32,22 +24,14 @@ These helpers include:
 * [`write_all`]: Write the entire contents of a buffer.
 * [`copy`]: Copy bytes from one I/O handle to another.
 
-A lot of these functions / helpers are generic over the [`AsyncRead`] and
-[`AsyncWrite`] traits. These traits are similar to [`Read`] and [`Write`] from
-`std`, but are only for types that are "future aware", i.e. follow the
-mandated properties:
+A lot of these functions / helpers are generic over the [`AsyncRead`] and [`AsyncWrite`] traits. These traits are similar to [`Read`] and [`Write`] from `std`, but are only for types that are "future aware", i.e. follow the mandated properties:
 
-* Calls to `read` or `write` are **nonblocking**, they never block the calling
-  thread.
-* If a call would otherwise block then the function returns a value indicating so.
-  If this happens then the current future's task is scheduled to receive a
-  notification when the I/O is ready again.
+* Calls to `read` or `write` are **nonblocking**, they never block the calling thread.
+* If a call would otherwise block then the function returns a value indicating so. If this happens then the current future's task is scheduled to receive a notification when the I/O is ready again.
 
-Note that users of [`AsyncRead`] and [`AsyncWrite`] types should use
-[`poll_read`] and [`poll_write`] instead of directly calling [`read`] and [`write`].
+Note that users of [`AsyncRead`] and [`AsyncWrite`] types should use [`poll_read`] and [`poll_write`] instead of directly calling [`read`] and [`write`].
 
-For example, here is how to accept connections, read 5 bytes from them, then
-write the 5 bytes back to the socket:
+For example, here is how to accept connections, read 5 bytes from them, then write the 5 bytes back to the socket:
 
 ```rust
 # #![deny(deprecated)]
@@ -81,12 +65,9 @@ let server = listener.incoming().for_each(|socket| {
 
 # Using the Poll API
 
-The Poll based API is to be used when implementing `Future` by hand and you need
-to return `Async`. This is useful when you need to implement your own
-combinators that handle custom logic.
+The Poll based API is to be used when implementing `Future` by hand and you need to return `Async`. This is useful when you need to implement your own combinators that handle custom logic.
 
-For example, this is how the `read_exact` future could be implemented for a
-`TcpStream`.
+For example, this is how the `read_exact` future could be implemented for a `TcpStream`.
 
 ```rust
 # #![deny(deprecated)]
@@ -152,14 +133,10 @@ impl Future for ReadExact {
 
 # Datagrams
 
-Note that most of this discussion has been around I/O or byte *streams*, which
-UDP importantly is not! To accommodate this, however, the [`UdpSocket`] type
-also provides a number of methods for working with it conveniently:
+Note that most of this discussion has been around I/O or byte *streams*, which UDP importantly is not! To accommodate this, however, the [`UdpSocket`] type also provides a number of methods for working with it conveniently:
 
-* [`send_dgram`] allows you to express sending a datagram as a future, returning
-  an error if the entire datagram couldn't be sent at once.
-* [`recv_dgram`] expresses reading a datagram into a buffer, yielding both the
-  buffer and the address it came from.
+* [`send_dgram`] allows you to express sending a datagram as a future, returning an error if the entire datagram couldn't be sent at once.
+* [`recv_dgram`] expresses reading a datagram into a buffer, yielding both the buffer and the address it came from.
 
 [`tokio`]: {{< api-url "tokio" >}}
 [`tokio::net`]: {{< api-url "tokio" >}}/net/index.html

--- a/content/docs/getting-started/runtime-model.md
+++ b/content/docs/getting-started/runtime-model.md
@@ -6,18 +6,13 @@ menu:
     parent: getting_started
 ---
 
-Now we will go over the Tokio / futures runtime model. Tokio is built on top of
-the [`futures`] crate and uses its runtime model. This allows it to interop
-with other libraries also using the [`futures`] crate.
+Now we will go over the Tokio / futures runtime model. Tokio is built on top of the [`futures`] crate and uses its runtime model. This allows it to interop with other libraries also using the [`futures`] crate.
 
-**Note**: This runtime model is very different than async libraries found in
-other languages. While, at a high level, APIs can look similar, the way code
-gets executed differs.
+**Note**: This runtime model is very different than async libraries found in other languages. While, at a high level, APIs can look similar, the way code gets executed differs.
 
 # Synchronous Model
 
-First, let's talk briefly about the synchronous (or blocking) model. This is the
-model that the Rust [standard library] uses.
+First, let's talk briefly about the synchronous (or blocking) model. This is the model that the Rust [standard library] uses.
 
 ```rust
 # use std::io::prelude::*;
@@ -31,48 +26,29 @@ let n = socket.read(&mut buf).unwrap();
 # }
 ```
 
-When `socket.read` is called, either the socket has pending data in its receive
-buffer or it does not. If there is pending data, then the call to `read` will
-return immediately and `buf` will be filled with that data. However, if there is
-no pending data, then the `read` function will block the current thread until
-data is received. At which time, `buf` will be filled with this newly received
-data and the `read` function will return.
+When `socket.read` is called, either the socket has pending data in its receive buffer or it does not. If there is pending data, then the call to `read` will return immediately and `buf` will be filled with that data. However, if there is no pending data, then the `read` function will block the current thread until data is received. At which time, `buf` will be filled with this newly received data and the `read` function will return.
 
-In order to perform reads on many different sockets concurrently, a thread per
-socket is required. Using a thread per socket does not scale up very well to
-large numbers of sockets. This is known as the [c10k] problem.
+In order to perform reads on many different sockets concurrently, a thread per socket is required. Using a thread per socket does not scale up very well to large numbers of sockets. This is known as the [c10k] problem.
 
 # Non-blocking sockets
 
-The way to avoid blocking a thread when performing an operation like read is to
-not block the thread! When the socket has no pending data in its receive buffer,
-the `read` function returns immediately, indicating that the socket was "not
-ready" to perform the read operation.
+The way to avoid blocking a thread when performing an operation like read is to not block the thread! When the socket has no pending data in its receive buffer, the `read` function returns immediately, indicating that the socket was "not ready" to perform the read operation.
 
-When using a Tokio [`TcpStream`], a call to `read` will always immediately return
-a value ([`ErrorKind::WouldBlock`]) even if there is no pending data to read.
-If there is no pending data, the caller is responsible for calling `read` again
-at a later time.  The trick is to know when that "later time" is.
+When using a Tokio [`TcpStream`], a call to `read` will always immediately return a value ([`ErrorKind::WouldBlock`]) even if there is no pending data to read. If there is no pending data, the caller is responsible for calling `read` again at a later time.  The trick is to know when that "later time" is.
 
-Another way to think about a non-blocking read is as "polling" the socket for
-data to read.
+Another way to think about a non-blocking read is as "polling" the socket for data to read.
 
 # Polling Model
 
-The strategy of polling a socket for data can be generalized to any operation.
-For example, a function to get a "widget" in the polling model would look
-something like this:
+The strategy of polling a socket for data can be generalized to any operation. For example, a function to get a "widget" in the polling model would look something like this:
 
 ```rust,ignore
 fn poll_widget() -> Async<Widget> { ... }
 ```
 
-This function returns an `Async<Widget>` where [`Async`] is an enum of
-`Ready(Widget)` or `NotReady`. The [`Async`] enum is provided by the [`futures`]
-crate and is one of the building blocks of the polling model.
+This function returns an `Async<Widget>` where [`Async`] is an enum of `Ready(Widget)` or `NotReady`. The [`Async`] enum is provided by the [`futures`] crate and is one of the building blocks of the polling model.
 
-Now, lets define an asynchronous task without combinators that uses this
-`poll_widget` function. The task will do the following:
+Now, lets define an asynchronous task without combinators that uses this `poll_widget` function. The task will do the following:
 
 1. Acquire a widget.
 2. Print the widget to STDOUT.
@@ -114,29 +90,17 @@ impl Future for MyTask {
 # }
 ```
 
-> **Important**: Returning `Async::NotReady` has special meaning. See the [next
-> section] for more details.
+> **Important**: Returning `Async::NotReady` has special meaning. See the [next section] for more details.
 
-The key thing to note is, when `MyTask::poll` is called, it immediately tries to
-get the widget. If the call to `poll_widget` returns `NotReady`, then the task
-is unable to make further progress. The task then returns `NotReady` itself,
-indicating that it is not ready to complete processing.
+The key thing to note is, when `MyTask::poll` is called, it immediately tries to get the widget. If the call to `poll_widget` returns `NotReady`, then the task is unable to make further progress. The task then returns `NotReady` itself, indicating that it is not ready to complete processing.
 
-The task implementation does not block. Instead, "sometime in the future", the
-executor will call `MyTask::poll` again. `poll_widget` will be called again. If
-`poll_widget` is ready to return a widget, then the task, in turn, is ready to
-print the widget. The task can then complete by returning `Ready`.
+The task implementation does not block. Instead, "sometime in the future", the executor will call `MyTask::poll` again. `poll_widget` will be called again. If `poll_widget` is ready to return a widget, then the task, in turn, is ready to print the widget. The task can then complete by returning `Ready`.
 
 # Executors
 
-In order for the task to make progress, something has to call `MyTask::poll`.
-This is the job of an executor.
+In order for the task to make progress, something has to call `MyTask::poll`. This is the job of an executor.
 
-Executors are responsible for repeatedly calling `poll` on a task until `Ready`
-is returned. There are many different ways to do this. For example, the
-[`CurrentThread`] executor will block the current thread and loop through all
-spawned tasks, calling poll on them. [`ThreadPool`] schedules tasks across a thread
-pool. This is also the default executor used by the [runtime][rt].
+Executors are responsible for repeatedly calling `poll` on a task until `Ready` is returned. There are many different ways to do this. For example, the [`CurrentThread`] executor will block the current thread and loop through all spawned tasks, calling poll on them. [`ThreadPool`] schedules tasks across a thread pool. This is also the default executor used by the [runtime][rt].
 
 All tasks **must** be spawned on an executor or no work will be performed.
 
@@ -177,12 +141,9 @@ impl SpinExecutor {
 # pub fn main() {}
 ```
 
-Of course, this would not be very efficient. The executor spins in a busy loop
-and tries to poll all tasks even if the task will just return `NotReady` again.
+Of course, this would not be very efficient. The executor spins in a busy loop and tries to poll all tasks even if the task will just return `NotReady` again.
 
-Ideally, there would be some way for the executor to know when the "readiness"
-state of a task is changed, i.e. when a call to `poll` will return `Ready`.
-Then, the executor would look something like this:
+Ideally, there would be some way for the executor to know when the "readiness" state of a task is changed, i.e. when a call to `poll` will return `Ready`. Then, the executor would look something like this:
 
 ```rust
 # #![deny(deprecated)]
@@ -221,8 +182,7 @@ Then, the executor would look something like this:
 # pub fn main() {}
 ```
 
-Being able to get notified when a task goes from "not ready" to "ready" is the
-core of the [`futures`] task model. We will be digging more into that shortly.
+Being able to get notified when a task goes from "not ready" to "ready" is the core of the [`futures`] task model. We will be digging more into that shortly.
 
 [`futures`]: {{< api-url "futures" >}}
 [standard library]: https://doc.rust-lang.org/std/

--- a/content/docs/going-deeper/building-runtime.md
+++ b/content/docs/going-deeper/building-runtime.md
@@ -6,64 +6,31 @@ menu:
     parent: going_deeper
 ---
 
-The runtime ‒ all the pieces needed to run an event driven application ‒ is
-already available. You don't *need* to know this if you want to just use tokio.
-However, it may be useful to know what happens under the hood, both to gain some
-more understanding of the details in case something goes wrong, and to be able
-to customize it beyond what the [runtime `Builder`] supports.
+The runtime ‒ all the pieces needed to run an event driven application ‒ is already available. You don't *need* to know this if you want to just use tokio. However, it may be useful to know what happens under the hood, both to gain some more understanding of the details in case something goes wrong, and to be able to customize it beyond what the [runtime `Builder`] supports.
 
-We are going to build a single threaded runtime, because it is slightly simpler
-to put together. Not that the default multi threaded one would be conceptually
-more complex, but there are more moving parts around. Knowing the details here
-can be a stepping stone to reading the code of the default runtime.
+We are going to build a single threaded runtime, because it is slightly simpler to put together. Not that the default multi threaded one would be conceptually more complex, but there are more moving parts around. Knowing the details here can be a stepping stone to reading the code of the default runtime.
 
-A complete, working example of things discussed here can be found in the
-[git repository](https://github.com/tokio-rs/tokio/tree/master/examples/manual-runtime.rs).
+A complete, working example of things discussed here can be found in the [git repository](https://github.com/tokio-rs/tokio/tree/master/examples/manual-runtime.rs).
 
 # The `Park` trait
 
-The asynchronous world is inherently about *waiting* for something to happen
-(and being able to wait for multiple things at once). It is no surprise there's
-a trait to abstract over the waiting. It's called [`Park`].
+The asynchronous world is inherently about *waiting* for something to happen (and being able to wait for multiple things at once). It is no surprise there's a trait to abstract over the waiting. It's called [`Park`].
 
-The idea is, if there's nothing better to do, the control is passed to the
-`Park` until something interesting happens and the control is taken away from it
-again or until some specified time passes. It is up to the `Park` how it spends
-this time. It can either do something useful (processing background jobs) or
-simply block the thread in some way.
+The idea is, if there's nothing better to do, the control is passed to the `Park` until something interesting happens and the control is taken away from it again or until some specified time passes. It is up to the `Park` how it spends this time. It can either do something useful (processing background jobs) or simply block the thread in some way.
 
-Some things are the bottom `Park` implementations ‒ they somehow block the
-thread. Other things implementing the trait only delegate the park calls to some
-underlying object they wrap (with some added functionality), allowing to stack
-things onto each other.
+Some things are the bottom `Park` implementations ‒ they somehow block the thread. Other things implementing the trait only delegate the park calls to some underlying object they wrap (with some added functionality), allowing to stack things onto each other.
 
 # The usual components
 
-We definitely need a [`Reactor`] to accept external events (like network sockets
-being readable) from the OS. It does so by blocking on `epoll`, `kqueue` or
-other OS-dependent primitive, through the [mio] crate. This can't delegate the
-waiting to anything else, so the reactor goes to the bottom of our stack.
+We definitely need a [`Reactor`] to accept external events (like network sockets being readable) from the OS. It does so by blocking on `epoll`, `kqueue` or other OS-dependent primitive, through the [mio] crate. This can't delegate the waiting to anything else, so the reactor goes to the bottom of our stack.
 
-The reactor is able to notify our futures of data coming over the network and
-similar events, but we need an executor to actually run them. We'll be using the
-[`CurrentThread`] executor, because we're building a single-threaded runtime.
-Use any other executor that suits your needs. The executor needs a `Park`
-underneath to wait when there are no futures ready to run. It doesn't implement
-`Park`, therefore it must go on the top of the whole stack.
+The reactor is able to notify our futures of data coming over the network and similar events, but we need an executor to actually run them. We'll be using the [`CurrentThread`] executor, because we're building a single-threaded runtime. Use any other executor that suits your needs. The executor needs a `Park` underneath to wait when there are no futures ready to run. It doesn't implement `Park`, therefore it must go on the top of the whole stack.
 
-While not strictly necessary, it is useful to be able to run delayed futures ‒
-timeouts and similar. Therefore, we place the [`Timer`] in the middle ‒
-fortunately, it can be placed on top of one `Park` and also implements `Park`.
-This plays a similar role for timeouts as reactor does for IO-based futures.
+While not strictly necessary, it is useful to be able to run delayed futures ‒ timeouts and similar. Therefore, we place the [`Timer`] in the middle ‒ fortunately, it can be placed on top of one `Park` and also implements `Park`. This plays a similar role for timeouts as reactor does for IO-based futures.
 
-In addition, any custom layer can be added. One example could be some kind of
-idle bookkeeping component ‒ it would try to repeatedly do a bit of work if
-asked to wait and interleave it with letting the park below it also pick up
-events. If there was no bookkeeping to be done, it would simply delegate the
-waiting.
+In addition, any custom layer can be added. One example could be some kind of idle bookkeeping component ‒ it would try to repeatedly do a bit of work if asked to wait and interleave it with letting the park below it also pick up events. If there was no bookkeeping to be done, it would simply delegate the waiting.
 
-This is how the creation of the reactor, timer and executor would look like in
-code:
+This is how the creation of the reactor, timer and executor would look like in code:
 
 ```rust
 # extern crate futures;
@@ -94,26 +61,15 @@ let mut executor = CurrentThread::new_with_park(timer);
 # }
 ```
 
-This way, if there are futures to execute, they'll get executed first. Then once
-it runs out of ready futures, it'll look for timeouts to fire. This may generate
-some more ready futures (which would get executed next). If no timeouts fire,
-the timer computes for how long the reactor can safely block and lets it wait
-for external events.
+This way, if there are futures to execute, they'll get executed first. Then once it runs out of ready futures, it'll look for timeouts to fire. This may generate some more ready futures (which would get executed next). If no timeouts fire, the timer computes for how long the reactor can safely block and lets it wait for external events.
 
 # Global state
 
-We've built the components that do the actual work. But we need a way to build
-and submit the work to them. We could do so through the handles, but to do that,
-we would have to carry them around which would be far from ergonomic.
+We've built the components that do the actual work. But we need a way to build and submit the work to them. We could do so through the handles, but to do that, we would have to carry them around which would be far from ergonomic.
 
-To avoid the tedious passing of several handles around, the built-in runtime
-stores them in a thread local storage. Several modules in tokio have a
-`with_default` method, which takes the corresponding handle and a closure. It
-stores the handle in the thread local storage and runs the closure. It then
-restores the original value of the TLS after the closure finishes.
+To avoid the tedious passing of several handles around, the built-in runtime stores them in a thread local storage. Several modules in tokio have a `with_default` method, which takes the corresponding handle and a closure. It stores the handle in the thread local storage and runs the closure. It then restores the original value of the TLS after the closure finishes.
 
-This way we would run a future with all the default values set, so it can freely
-use them:
+This way we would run a future with all the default values set, so it can freely use them:
 
 ```rust
 # extern crate futures;
@@ -163,25 +119,11 @@ let result = tokio_reactor::with_default(
 # }
 ```
 
-There are a few things of note. First, the `enter` thing just ensures that we
-don't run multiple executors on the same thread at the same time. Running
-multiple executors would get one of them blocked, which would act in a very not
-useful way, therefore this is footgun prevention.
+There are a few things of note. First, the `enter` thing just ensures that we don't run multiple executors on the same thread at the same time. Running multiple executors would get one of them blocked, which would act in a very not useful way, therefore this is footgun prevention.
 
-Second, we want to use the same executor as the default executor and default
-current thread executor, and also to run the executor (not only spawn a future
-onto it without further waiting). To do both, we need two mutable references to
-it, which is not possible. To work around that, we set the current thread
-executor (it actually sets itself, in the `executor.block_on` call, or any
-similar one). We use the `TaskExecutor` as the default one, which is a proxy to
-whatever current thread executor is configured at the time of its use.
+Second, we want to use the same executor as the default executor and default current thread executor, and also to run the executor (not only spawn a future onto it without further waiting). To do both, we need two mutable references to it, which is not possible. To work around that, we set the current thread executor (it actually sets itself, in the `executor.block_on` call, or any similar one). We use the `TaskExecutor` as the default one, which is a proxy to whatever current thread executor is configured at the time of its use.
 
-Finally, the `block_on` will execute the single future to completion (and will
-process any other futures spawned in the executor as well, but it'll not wait
-for them to finish if `f` finishes first). The result of the future is bubbled
-upwards through all the `with_default` calls and can be returned or used in any
-other way. If you want to wait for all the other futures to finish too, there's
-also `executor.run` which can be executed afterwards.
+Finally, the `block_on` will execute the single future to completion (and will process any other futures spawned in the executor as well, but it'll not wait for them to finish if `f` finishes first). The result of the future is bubbled upwards through all the `with_default` calls and can be returned or used in any other way. If you want to wait for all the other futures to finish too, there's also `executor.run` which can be executed afterwards.
 
 [runtime `Builder`]: {{< api-url "tokio" >}}/runtime/struct.Builder.html
 [`Park`]: {{< api-url "tokio-executor" >}}/park/trait.Park.html

--- a/content/docs/going-deeper/frames.md
+++ b/content/docs/going-deeper/frames.md
@@ -6,24 +6,15 @@ menu:
     parent: going_deeper
 ---
 
-Tokio has helpers to transform a stream of bytes into a stream of frames. Examples
-of byte streams include TCP connections, pipes, file objects and the standard
-input and output file descriptors. In Rust, streams are easily identified
-because they implement the `Read` and `Write` traits.
+Tokio has helpers to transform a stream of bytes into a stream of frames. Examples of byte streams include TCP connections, pipes, file objects and the standard input and output file descriptors. In Rust, streams are easily identified because they implement the `Read` and `Write` traits.
 
-One of the simplest forms of framed message is the line delimited message.
-Each message ends with a `\n` character. Let's look at how one would implement
-a stream of line delimited messages with tokio.
+One of the simplest forms of framed message is the line delimited message. Each message ends with a `\n` character. Let's look at how one would implement a stream of line delimited messages with tokio.
 
 # Writing a codec
 
-The codec implements the `tokio_codec::Decoder` and
-`tokio_codec::Encoder` traits. Its job is to convert a frame to and from
-bytes. Those traits are used in conjunction with the `tokio_codec::Framed`
-struct to provide buffering, decoding and encoding of byte streams.
+The codec implements the `tokio_codec::Decoder` and `tokio_codec::Encoder` traits. Its job is to convert a frame to and from bytes. Those traits are used in conjunction with the `tokio_codec::Framed` struct to provide buffering, decoding and encoding of byte streams.
 
-Let's look at a simplified version of the `LinesCodec` struct, which implements
-decoding and encoding of the line delimited message.
+Let's look at a simplified version of the `LinesCodec` struct, which implements decoding and encoding of the line delimited message.
 
 ```rust
 pub struct LinesCodec {
@@ -37,17 +28,9 @@ pub struct LinesCodec {
 }
 ```
 
-The comments here explain how, since the bytes are buffered until a line is
-found, it is wasteful to search for a `\n` from the beginning of the buffer
-everytime data is received. It's more efficient to keep the last length of
-the buffer and start searching from there when new data is received.
+The comments here explain how, since the bytes are buffered until a line is found, it is wasteful to search for a `\n` from the beginning of the buffer everytime data is received. It's more efficient to keep the last length of the buffer and start searching from there when new data is received.
 
-The `Decoder::decode` method is called when data is received on the underlying
-stream. The method can produce a frame or return `Ok(None)` to signify that
-it needs more data to produce a frame. The `decode` method is responsible
-for removing the data that no longer needs to be buffered by splitting it off
-using the `BytesMut` methods. If the data is not removed, the buffer will
-keep growing.
+The `Decoder::decode` method is called when data is received on the underlying stream. The method can produce a frame or return `Ok(None)` to signify that it needs more data to produce a frame. The `decode` method is responsible for removing the data that no longer needs to be buffered by splitting it off using the `BytesMut` methods. If the data is not removed, the buffer will keep growing.
 
 Let's look at how `Decoder::decode` is implemented for `LinesCodec`.
 
@@ -102,10 +85,7 @@ fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<String>, io::Error> {
 # }
 ```
 
-The `Encoder::encode` method is called when a frame must be written to the
-underlying stream. The frame must be written to the buffer received as a
-parameter. The data written to the buffer will be written to the
-stream as it becomes ready to send the data.
+The `Encoder::encode` method is called when a frame must be written to the underlying stream. The frame must be written to the buffer received as a parameter. The data written to the buffer will be written to the stream as it becomes ready to send the data.
 
 Let's now look at how `Encoder::encode` is implemented for `LinesCodec`.
 
@@ -139,17 +119,12 @@ fn encode(&mut self, line: String, buf: &mut BytesMut) -> Result<(), io::Error> 
 # }
 ```
 
-It's often simpler to encode information. Here we simply reserve the space
-needed and write the data to the buffer.
+It's often simpler to encode information. Here we simply reserve the space needed and write the data to the buffer.
 
 # Using a codec
-The simplest way of using a codec is with the `Framed` struct. It's a wrapper
-around a codec that implements automatic buffering. The `Framed` struct is both
-a `Stream` and a `Sink`. Thus, you can receive frames from it and send frames
-to it.
+The simplest way of using a codec is with the `Framed` struct. It's a wrapper around a codec that implements automatic buffering. The `Framed` struct is both a `Stream` and a `Sink`. Thus, you can receive frames from it and send frames to it.
 
-You can create a `Framed` struct using any type that implements the `AsyncRead`
-and `AsyncWrite` traits using the `AsyncRead::framed` method.
+You can create a `Framed` struct using any type that implements the `AsyncRead` and `AsyncWrite` traits using the `AsyncRead::framed` method.
 
 ```rust
 # extern crate futures;

--- a/content/docs/going-deeper/futures-mechanics.md
+++ b/content/docs/going-deeper/futures-mechanics.md
@@ -6,17 +6,11 @@ menu:
     parent: going_deeper
 ---
 
-We saw a few of the most important combinators in the
-[futures](../../getting-started/futures) and
-[streams](../../getting-started/streams-and-sinks) overviews. Here we'll take a
-look at a few more. It's also worth spending some time with the trait
-documentation to familiarize yourself with the full range of combinators
-available ([cheatsheet](/img/diagrams/cheatsheet-for-futures.html)).
+We saw a few of the most important combinators in the [futures](../../getting-started/futures) and [streams](../../getting-started/streams-and-sinks) overviews. Here we'll take a look at a few more. It's also worth spending some time with the trait documentation to familiarize yourself with the full range of combinators available ([cheatsheet](/img/diagrams/cheatsheet-for-futures.html)).
 
 # Some concrete futures and streams
 
-Any value can be turned into an immediately complete future. There are a few
-functions in the `future` module for creating such a future:
+Any value can be turned into an immediately complete future. There are a few functions in the `future` module for creating such a future:
 
 - [`ok`], which is analogous to `Result::Ok`: it treats the value you give it as an immediately successful future.
 - [`err`], which is analogous to `Result::Err`: it treats the value you give it as an immediately failed future.
@@ -28,39 +22,28 @@ functions in the `future` module for creating such a future:
 
 For streams, there are a few equivalents of an "immediately ready" stream:
 
-- [`iter`], which creates a stream that yields the same items as the underlying
-iterator. The iterator produces `Result` values, and the first error terminates
-the stream with that error.
+- [`iter`], which creates a stream that yields the same items as the underlying iterator. The iterator produces `Result` values, and the first error terminates the stream with that error.
 - [`once`], which creates a single-element stream from a `Result`.
 
 [`iter`]: https://docs.rs/futures/0.1/futures/stream/fn.iter.html
 [`once`]: https://docs.rs/futures/0.1/futures/stream/fn.once.html
 
-In addition to these constructors, there's also a function, [`lazy`], which
-allows you to construct a future given a *closure* that will produce that future
-later, on demand.
+In addition to these constructors, there's also a function, [`lazy`], which allows you to construct a future given a *closure* that will produce that future later, on demand.
 
 [`lazy`]: https://docs.rs/futures/0.1/futures/future/fn.lazy.html
 
 # IntoFuture
 
-A crucial API to know about is the [`IntoFuture`] trait, which is a trait for
-values that can be converted into futures. Most APIs that you think of as taking
-futures actually work with this trait instead. The key reason: the trait is
-implemented for `Result`, allowing you to return `Result` values in many places
-that futures are expected.
+A crucial API to know about is the [`IntoFuture`] trait, which is a trait for values that can be converted into futures. Most APIs that you think of as taking futures actually work with this trait instead. The key reason: the trait is implemented for `Result`, allowing you to return `Result` values in many places that futures are expected.
 
 [`IntoFuture`]: https://docs.rs/futures/0.1/futures/future/trait.IntoFuture.html
 
 # Adapters
 
-Like [`Iterator`], the `Future`, `Stream` and `Sink` traits all come equipped
-with a broad range of "adapter" methods. These methods all consume the receiving
-object and return a new, wrapped one. For futures, you can use adapters to:
+Like [`Iterator`], the `Future`, `Stream` and `Sink` traits all come equipped with a broad range of "adapter" methods. These methods all consume the receiving object and return a new, wrapped one. For futures, you can use adapters to:
 
 * Change the type of a future ([`map`], [`map_err`])
-* Run another future after one has completed ([`then`], [`and_then`],
-  [`or_else`])
+* Run another future after one has completed ([`then`], [`and_then`], [`or_else`])
 * Figure out which of two futures resolves first ([`select`])
 * Wait for two futures to both complete ([`join`])
 * Convert to a trait object ([`Box::new`])
@@ -80,12 +63,8 @@ object and return a new, wrapped one. For futures, you can use adapters to:
 
 For streams, there are a large set of adapters, including:
 
-* Many in common with [`Iterator`], like [`map`][stream-map], [`fold`],
-  [`collect`], [`filter`], [`zip`], [`take`], [`skip`] and so on. Note that [`fold`] and
-  [`collect`] produce *futures*, and hence their result is computed
-  asynchronously.
-* Adapters for sequencing with futures ([`then`][stream-then],
-  [`and_then`][stream-and_then], [`or_else`][stream-or_else])
+* Many in common with [`Iterator`], like [`map`][stream-map], [`fold`], [`collect`], [`filter`], [`zip`], [`take`], [`skip`] and so on. Note that [`fold`] and [`collect`] produce *futures*, and hence their result is computed asynchronously.
+* Adapters for sequencing with futures ([`then`][stream-then], [`and_then`][stream-and_then], [`or_else`][stream-or_else])
 * Additional adapters for combining streams ([`merge`], [`select`][stream-select])
 
 [stream-map]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html#method.map
@@ -101,37 +80,21 @@ For streams, there are a large set of adapters, including:
 [`merge`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html#method.merge
 [stream-select]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html#method.select
 
-The `Sink` trait currently has fewer adapters<!--TODO: fix this link; the most important ones were
-covered in [the introduction](../../getting-started/streams-and-sinks).-->
+The `Sink` trait currently has fewer adapters<!--TODO: fix this link; the most important ones were covered in [the introduction](../../getting-started/streams-and-sinks).-->
 
 Finally, an object that is both a stream and a sink can be broken into separate
 stream and sink objects using the [`split`] adapter.
 
 [`split`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html#method.split
 
-All adapters are zero-cost, meaning that no memory is allocated internally and
-the implementation will optimize to what you would have otherwise written by
-hand.
+All adapters are zero-cost, meaning that no memory is allocated internally and the implementation will optimize to what you would have otherwise written by hand.
 
 # Error handling
 
-Futures, streams and sinks all treat error handling as a core concern: they are
-all equipped with an associated error type, and the various adapter methods
-interpret errors in sensible ways. For example:
+Futures, streams and sinks all treat error handling as a core concern: they are all equipped with an associated error type, and the various adapter methods interpret errors in sensible ways. For example:
 
-- The sequencing combinators [`then`], [`and_then`], [`or_else`], [`map`], and
-  [`map_err`] all chain errors similarly to the `Result` type in the standard
-  library. So, for example, if you chain futures using [`and_then`] and the
-  first future fails with an error, the chained future is never run.
+- The sequencing combinators [`then`], [`and_then`], [`or_else`], [`map`], and [`map_err`] all chain errors similarly to the `Result` type in the standard library. So, for example, if you chain futures using [`and_then`] and the first future fails with an error, the chained future is never run.
 
-- Combinators like [`select`] and [`join`] also deal with errors. For
-  [`select`], the first future to complete *in any way* yields an answer,
-  propagating the error, but also giving access to the other future should you
-  want to keep working with it. For [`join`], if any future produces an error,
-  the entire join produces that error.
+- Combinators like [`select`] and [`join`] also deal with errors. For [`select`], the first future to complete *in any way* yields an answer, propagating the error, but also giving access to the other future should you want to keep working with it. For [`join`], if any future produces an error, the entire join produces that error.
 
-By default, futures don't have any special handling for panics. In most cases,
-though, futures are ultimately run as tasks within a thread pool, where you'll
-want to catch any panic they produce and propagate that elsewhere. The
-[`catch_unwind`] adapter can be used to reify a panic into a `Result` without
-taking down the worker thread.
+By default, futures don't have any special handling for panics. In most cases, though, futures are ultimately run as tasks within a thread pool, where you'll want to catch any panic they produce and propagate that elsewhere. The [`catch_unwind`] adapter can be used to reify a panic into a `Result` without taking down the worker thread.

--- a/content/docs/going-deeper/timers.md
+++ b/content/docs/going-deeper/timers.md
@@ -6,21 +6,17 @@ menu:
     parent: going_deeper
 ---
 
-When writing a network based application, it is common to need to perform
-actions based on time.
+When writing a network based application, it is common to need to perform actions based on time.
 
 * Run some code after a set period of time.
 * Cancel a running operation that takes too long.
 * Repeatedly perform an action at an interval.
 
-These use cases are handled by using the various timer APIs that are provided in
-the [timer] module.
+These use cases are handled by using the various timer APIs that are provided in the [timer] module.
 
 # Running code after a period of time
 
-In this case, we want to perform a task after a set period of time. To do this,
-we use the [`Delay`][delay] API. All we will do is write `"Hello world!"` to the
-terminal, but any action can be taken at this point.
+In this case, we want to perform a task after a set period of time. To do this, we use the [`Delay`][delay] API. All we will do is write `"Hello world!"` to the terminal, but any action can be taken at this point.
 
 ```rust
 # #![deny(deprecated)]
@@ -44,27 +40,17 @@ fn main() {
 }
 ```
 
-The above example creates a new `Delay` instance that will complete 100
-milliseconds in the future. The `new` function takes an `Instant`, so we compute
-`when` to be the instant 100 milliseconds from now.
+The above example creates a new `Delay` instance that will complete 100 milliseconds in the future. The `new` function takes an `Instant`, so we compute `when` to be the instant 100 milliseconds from now.
 
-Once the instant is reached, the `Delay` future completes, resulting in the
-`and_then` block to be executed.
+Once the instant is reached, the `Delay` future completes, resulting in the `and_then` block to be executed.
 
-As with all futures, `Delay` is lazy. Simply creating a new `Delay` instance
-does nothing. The instance must be used on a task that is spawned onto the Tokio
-[runtime]. The [runtime] comes preconfigured with a timer implementation to
-drive the `Delay` instance to completion. In the example above, this is done by
-passing the task to `tokio::run`. Using `tokio::spawn` would also work.
+As with all futures, `Delay` is lazy. Simply creating a new `Delay` instance does nothing. The instance must be used on a task that is spawned onto the Tokio [runtime]. The [runtime] comes preconfigured with a timer implementation to drive the `Delay` instance to completion. In the example above, this is done by passing the task to `tokio::run`. Using `tokio::spawn` would also work.
 
 # Timing out a long running operation
 
-When writing robust networking applications, it's critical to ensure that
-operations complete within reasonable amounts of time. This is especially true
-when waiting for data from external, potentially untrusted, sources.
+When writing robust networking applications, it's critical to ensure that operations complete within reasonable amounts of time. This is especially true when waiting for data from external, potentially untrusted, sources.
 
-The [`Timeout`][timeout] type ensures that an operation completes by a specified
-instant in time.
+The [`Timeout`][timeout] type ensures that an operation completes by a specified instant in time.
 
 ```rust
 # #![deny(deprecated)]
@@ -89,27 +75,15 @@ fn read_four_bytes(socket: TcpStream)
 # pub fn main() {}
 ```
 
-The above function takes a socket and returns a future that completes when 4
-bytes have been read from the socket. The read must complete within 5 seconds.
-This is ensured by calling `timeout` on the read future with a duration of 5
-seconds.
+The above function takes a socket and returns a future that completes when 4 bytes have been read from the socket. The read must complete within 5 seconds. This is ensured by calling `timeout` on the read future with a duration of 5 seconds.
 
-The [`timeout`] function is defined by [`FutureExt`][ext] and is included in the
-prelude. As such, `use tokio::prelude::*` imports [`FutureExt`][ext] as well, so
-we can call [`timeout`] on all futures in order to require them to complete by
-the specified instant.
+The [`timeout`] function is defined by [`FutureExt`][ext] and is included in the prelude. As such, `use tokio::prelude::*` imports [`FutureExt`][ext] as well, so we can call [`timeout`] on all futures in order to require them to complete by the specified instant.
 
-If the timeout is reached without the read completing, the read operation is
-automatically canceled. This happens when the future returned by
-`io::read_exact` is dropped. Because of the lazy runtime model, dropping a
-future results in the operation being canceled.
+If the timeout is reached without the read completing, the read operation is automatically canceled. This happens when the future returned by `io::read_exact` is dropped. Because of the lazy runtime model, dropping a future results in the operation being canceled.
 
 # Running code on an interval
 
-Repeatedly running code on an interval is useful for cases like sending a PING
-message on a socket, or checking a configuration file every so often. This can
-be implemented by repeatedly creating [`Delay`][delay] values. However, because
-this is a common pattern, [`Interval`][interval] is provided.
+Repeatedly running code on an interval is useful for cases like sending a PING message on a socket, or checking a configuration file every so often. This can be implemented by repeatedly creating [`Delay`][delay] values. However, because this is a common pattern, [`Interval`][interval] is provided.
 
 The [`Interval`] type implements `Stream`, yielding at the specified rate.
 
@@ -135,32 +109,17 @@ fn main() {
 }
 ```
 
-The above example creates an `Interval` that yields every 100 milliseconds
-starting now (the first argument is the instant at which the `Interval` should
-first fire).
+The above example creates an `Interval` that yields every 100 milliseconds starting now (the first argument is the instant at which the `Interval` should first fire).
 
-By default, an `Instant` stream is unbounded, i.e., it will continue yielding at
-the requested interval forever. The example uses `Stream::take` to limit the
-number of times `Interval` yields, here limiting to a sequence of 10 events.
-So, the example will run for 0.9 seconds since the first of 10 values is yielded
-immediately.
+By default, an `Instant` stream is unbounded, i.e., it will continue yielding at the requested interval forever. The example uses `Stream::take` to limit the number of times `Interval` yields, here limiting to a sequence of 10 events. So, the example will run for 0.9 seconds since the first of 10 values is yielded immediately.
 
 # Notes on the timer
 
-The Tokio timer has a granularity of one millisecond. Any smaller interval is
-rounded up to the nearest millisecond. The timer is implemented in user land
-(i.e., does not use an operating system timer like `timerfd` on linux). It uses
-a hierarchical hashed timer wheel implementation, which provides efficient
-constant time complexity when creating, canceling, and firing timeouts.
+The Tokio timer has a granularity of one millisecond. Any smaller interval is rounded up to the nearest millisecond. The timer is implemented in user land (i.e., does not use an operating system timer like `timerfd` on linux). It uses a hierarchical hashed timer wheel implementation, which provides efficient constant time complexity when creating, canceling, and firing timeouts.
 
-The Tokio runtime includes one timer instance **per worker thread**. This means
-that, if the runtime starts 4 worker threads, there will be 4 timer
-instances. This allows avoiding synchronization in most cases since the task,
-when working with a timer, will be operating on state located on the current
-thread.
+The Tokio runtime includes one timer instance **per worker thread**. This means that, if the runtime starts 4 worker threads, there will be 4 timer instances. This allows avoiding synchronization in most cases since the task, when working with a timer, will be operating on state located on the current thread.
 
-That said, the timer implementation is thread safe and supports usage from
-any thread.
+That said, the timer implementation is thread safe and supports usage from any thread.
 
 [timer]: {{< api-url "tokio" >}}/timer/index.html
 [delay]: {{< api-url "tokio" >}}/timer/struct.Delay.html

--- a/content/docs/internals/intro.md
+++ b/content/docs/internals/intro.md
@@ -6,13 +6,9 @@ menu:
     parent: "internals"
 ---
 
-The internals section provides an in-depth guide of Tokio's internals. It
-expects the reader already has a good understanding of how to use Tokio. Those
-unfamiliar with Tokio should start with the [getting started][guide] guide.
+The internals section provides an in-depth guide of Tokio's internals. It expects the reader already has a good understanding of how to use Tokio. Those unfamiliar with Tokio should start with the [getting started][guide] guide.
 
 [guide]: {{< ref "/docs/getting-started/hello-world.md" >}}
 
-* [Runtime model]({{< relref "runtime-model.md" >}}) - An overview of Tokio's
-  asynchronous runtime model.
-* [Non-blocking I/O]({{<relref "net.md" >}}) - Implementation details of Tokio's
-  network related types (TCP, UDP, ...).
+* [Runtime model]({{< relref "runtime-model.md" >}}) - An overview of Tokio's asynchronous runtime model.
+* [Non-blocking I/O]({{<relref "net.md" >}}) - Implementation details of Tokio's network related types (TCP, UDP, ...).

--- a/content/docs/internals/runtime-model.md
+++ b/content/docs/internals/runtime-model.md
@@ -6,13 +6,7 @@ menu:
     parent: "internals"
 ---
 
-Applications written using Tokio are organized across a large number of small,
-non-blocking tasks. A Tokio task is similar to a [goroutine][goroutine] or an
-[Erlang process][erlang], but is non-blocking. They are designed to be
-lightweight, can be spawned fast, and maintain low scheduling overhead. They are
-also non-blocking, as such operations that are not able to finish immediately
-must still return immediately. Instead of returning the result of the operation,
-they return a value indicating that the operation is in progress.
+Applications written using Tokio are organized across a large number of small, non-blocking tasks. A Tokio task is similar to a [goroutine][goroutine] or an [Erlang process][erlang], but is non-blocking. They are designed to be lightweight, can be spawned fast, and maintain low scheduling overhead. They are also non-blocking, as such operations that are not able to finish immediately must still return immediately. Instead of returning the result of the operation, they return a value indicating that the operation is in progress.
 
 [goroutine]: https://www.golang-book.com/books/intro/10#section1
 [erlang]: http://erlang.org/doc/reference_manual/processes.html
@@ -53,68 +47,34 @@ impl Future for MyTask {
 }
 ```
 
-Tasks are submitted to an executor using `tokio::spawn` or by calling a `spawn`
-method on an executor object. The `poll` function drives the task. No work is
-done without calling `poll`. It is the executor's job to call `poll` on the task
-until `Ready(())` is returned.
+Tasks are submitted to an executor using `tokio::spawn` or by calling a `spawn` method on an executor object. The `poll` function drives the task. No work is done without calling `poll`. It is the executor's job to call `poll` on the task until `Ready(())` is returned.
 
-`MyTask` will receive a value from `my_resource` and process it. Once the value
-has been processed, the task has completed its logic and is done. This is
-represented by returning `Ok(Async::Ready(()))`.
+`MyTask` will receive a value from `my_resource` and process it. Once the value has been processed, the task has completed its logic and is done. This is represented by returning `Ok(Async::Ready(()))`.
 
-However, in order to complete processing, the task depends on `my_resource`
-providing a value. Given that `my_resource` is a non-blocking task, it may or
-may not be ready to provide the value when `my_resource.poll()` is called. If it
-is ready, it returns `Ok(Async::Ready(value))`. If it is not ready, it returns
-`Ok(Async::NotReady)`.
+However, in order to complete processing, the task depends on `my_resource` providing a value. Given that `my_resource` is a non-blocking task, it may or may not be ready to provide the value when `my_resource.poll()` is called. If it is ready, it returns `Ok(Async::Ready(value))`. If it is not ready, it returns `Ok(Async::NotReady)`.
 
-When the resource is not ready to provide a value, this implies that the task
-itself is not ready to complete and the task's `poll` function returns
-`NotReady` as well.
+When the resource is not ready to provide a value, this implies that the task itself is not ready to complete and the task's `poll` function returns `NotReady` as well.
 
-At some point in the future, the resource will become ready to provide the
-value. The resource uses the task system to signal to the executor that it is
-ready. The executor schedules the task, which leads to `MyTask::poll` being
-called again. This time, given that `my_resource` is ready, the value will be
-returned from `my_resource.poll()` and the task is able to complete.
+At some point in the future, the resource will become ready to provide the value. The resource uses the task system to signal to the executor that it is ready. The executor schedules the task, which leads to `MyTask::poll` being called again. This time, given that `my_resource` is ready, the value will be returned from `my_resource.poll()` and the task is able to complete.
 
 [Future]: https://docs.rs/futures/0.1/futures/future/trait.Future.html
 
 ## Cooperative scheduling
 
-Cooperative scheduling is used to schedule tasks on executors. A single executor
-is expected to manage many tasks across a small set of threads. There will be
-a far greater number of tasks then threads. There also is no pre-emption. This
-means that when a task is scheduled to execute, it blocks the current thread
-until the `poll` function returns.
+Cooperative scheduling is used to schedule tasks on executors. A single executor is expected to manage many tasks across a small set of threads. There will be a far greater number of tasks then threads. There also is no pre-emption. This means that when a task is scheduled to execute, it blocks the current thread until the `poll` function returns.
 
-Because of this, it is important for implementations of `poll` to only execute
-for very short periods of time. For I/O bound applications, this usually happens
-automatically. However, if a task must run a longer computation, it should defer
-work to a [blocking pool] or break up the computation into smaller chunks and
-[yield] back to the executor after each chunk.
+Because of this, it is important for implementations of `poll` to only execute for very short periods of time. For I/O bound applications, this usually happens automatically. However, if a task must run a longer computation, it should defer work to a [blocking pool] or break up the computation into smaller chunks and [yield] back to the executor after each chunk.
 
 [blocking pool]: https://docs.rs/tokio-threadpool/0.1/tokio_threadpool/fn.blocking.html
 [yield]: #yielding
 
 # Task system
 
-The task system is the system by which resources notify executors of readiness
-changes. A task is composed of non-blocking logic that consume resources. In the
-example above, `MyTask` uses a single resource, `my_resource`, but there is no
-limit to the number of resources that a task can consume.
+The task system is the system by which resources notify executors of readiness changes. A task is composed of non-blocking logic that consume resources. In the example above, `MyTask` uses a single resource, `my_resource`, but there is no limit to the number of resources that a task can consume.
 
-When a task is executing and attempts to use a resource that is not ready, it
-becomes *logically* blocked on that resource, i.e., the task is not able to make
-further progress until that resource becomes ready. Tokio tracks which resources
-a task is currently blocked on to make forward progress. When a dependent
-resource becomes ready, the executor schedules the task. This is done by
-tracking when a task **expresses interest** in a resource.
+When a task is executing and attempts to use a resource that is not ready, it becomes *logically* blocked on that resource, i.e., the task is not able to make further progress until that resource becomes ready. Tokio tracks which resources a task is currently blocked on to make forward progress. When a dependent resource becomes ready, the executor schedules the task. This is done by tracking when a task **expresses interest** in a resource.
 
-When `MyTask` executes, attempts to consume `my_resource`, and `my_resource`
-returns `NotReady`, `MyTask` has implicitly expressed interest in the
-`my_resource` resource. At this point the task and the resource are linked. When
-the resource becomes ready, the task is scheduled again.
+When `MyTask` executes, attempts to consume `my_resource`, and `my_resource` returns `NotReady`, `MyTask` has implicitly expressed interest in the `my_resource` resource. At this point the task and the resource are linked. When the resource becomes ready, the task is scheduled again.
 
 ## `task::current` and `Task::notify`
 
@@ -123,36 +83,17 @@ Tracking interest and notifying readiness changes is done with two APIs:
   * [`task::current`][current]
   * [`Task::notify`][notify]
 
-When `my_resource.poll()` is called, if the resource is ready, it immediately
-returns the value without using the task system. If the resource is **not**
-ready, it gets a handle to the current task by calling [`task::current() ->
-Task`][current]. This handle is obtained by reading a thread-local variable set
-by the executor.
+When `my_resource.poll()` is called, if the resource is ready, it immediately returns the value without using the task system. If the resource is **not** ready, it gets a handle to the current task by calling [`task::current() -> Task`][current]. This handle is obtained by reading a thread-local variable set by the executor.
 
-Some external event (data received on the network, background thread completing
-a computation, etc...) will result in `my_resource` becoming ready to produce
-its value. At that point, the logic that readies `my_resource` will call
-[`notify`] on the task handle obtained from [`task::current`][current]. This
-signals the readiness change to the executor, which then schedules the task for
-execution.
+Some external event (data received on the network, background thread completing a computation, etc...) will result in `my_resource` becoming ready to produce its value. At that point, the logic that readies `my_resource` will call [`notify`] on the task handle obtained from [`task::current`][current]. This signals the readiness change to the executor, which then schedules the task for execution.
 
-If multiple tasks have expressed interest in a resource, only the *last* task to
-have done so will be notified. Resources are intended to be used from a single
-task only.
+If multiple tasks have expressed interest in a resource, only the *last* task to have done so will be notified. Resources are intended to be used from a single task only.
 
 ## `Async::NotReady`
 
-Any function that returns `Async` must adhere to the [contract][contract]. When
-`NotReady` is returned, the current task **must** have been registered for
-notification on readiness change. The implication for resources is discussed in
-the above section. For task logic, this means that `NotReady` cannot be returned
-unless a resource has returned `NotReady`. By doing this, the
-[contract][contract] transitively upheld. The current task is registered for
-notification because `NotReady` has been received from the resource.
+Any function that returns `Async` must adhere to the [contract][contract]. When `NotReady` is returned, the current task **must** have been registered for notification on readiness change. The implication for resources is discussed in the above section. For task logic, this means that `NotReady` cannot be returned unless a resource has returned `NotReady`. By doing this, the [contract][contract] transitively upheld. The current task is registered for notification because `NotReady` has been received from the resource.
 
-Great care must be taken to avoiding returning `NotReady` without having
-received `NotReady` from a resource. For example, the following task
-implementation results in the task never completing.
+Great care must be taken to avoiding returning `NotReady` without having received `NotReady` from a resource. For example, the following task implementation results in the task never completing.
 
 ```rust
 # #![deny(deprecated)]
@@ -198,11 +139,7 @@ impl Future for BadTask {
 # fn main() {}
 ```
 
-The problem with the above implementation is that `Ok(Async::NotReady)` is
-returned right after transitioning the state to `Second`. During this
-transition, no resource has returned `NotReady`. When the task itself returns
-`NotReady`, it has violated the [contract][contract] as the task will **not** be
-notified in the future.
+The problem with the above implementation is that `Ok(Async::NotReady)` is returned right after transitioning the state to `Second`. During this transition, no resource has returned `NotReady`. When the task itself returns `NotReady`, it has violated the [contract][contract] as the task will **not** be notified in the future.
 
 This situation is generally resolved by adding a loop:
 
@@ -249,19 +186,13 @@ fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
 # fn main() {}
 ```
 
-One way to think about it is that a task's `poll` function **must not**
-return until it is unable to make any further progress due to its resources not
-being ready or it explicitly yields (see below).
+One way to think about it is that a task's `poll` function **must not** return until it is unable to make any further progress due to its resources not being ready or it explicitly yields (see below).
 
-Also note that **functions that return `Async` must only be called from a
-task**. In other words, these functions may only be called from code that has
-been submitted to `tokio::spawn` or other task spawn function.
+Also note that **functions that return `Async` must only be called from a task**. In other words, these functions may only be called from code that has been submitted to `tokio::spawn` or other task spawn function.
 
 ### Yielding
 
-Sometimes a task must return `NotReady` without being blocked on a resource.
-This usually happens when computation to run is large and the task wants to
-return control to the executor to allow it to execute other futures.
+Sometimes a task must return `NotReady` without being blocked on a resource. This usually happens when computation to run is large and the task wants to return control to the executor to allow it to execute other futures.
 
 Yielding is done by notifying the current task and returning `NotReady`:
 
@@ -311,47 +242,19 @@ impl Future for Count {
 
 # Executors
 
-Executors are responsible for driving many tasks to completion. A task is
-spawned onto an executor, at which point the executor calls its `poll` function
-when needed. The executor hooks into the task system to receive resource
-readiness notifications.
+Executors are responsible for driving many tasks to completion. A task is spawned onto an executor, at which point the executor calls its `poll` function when needed. The executor hooks into the task system to receive resource readiness notifications.
 
-By decoupling the task system with the executor implementation, the specific
-execution and scheduling logic can be left to the executor implementation. Tokio
-provides two executor implementations, each with unique characteristics:
-[`current_thread`] and [`thread_pool`].
+By decoupling the task system with the executor implementation, the specific execution and scheduling logic can be left to the executor implementation. Tokio provides two executor implementations, each with unique characteristics: [`current_thread`] and [`thread_pool`].
 
-When a task is first spawned onto the executor, the executor wraps it with
-[`Spawn`][Spawn]. This binds the task logic with the task state (this is mostly
-required for legacy reasons). Executors will typically store the task on the
-heap, usually by storing it in a `Box` or an `Arc`. When the executor picks a
-task for execution, it calls [`Spawn::poll_future_notify`][poll_future_notify].
-This function ensures that the task context is set to the thread-local variable
-such that [`task::current`][current] is able to read it.
+When a task is first spawned onto the executor, the executor wraps it with [`Spawn`][Spawn]. This binds the task logic with the task state (this is mostly required for legacy reasons). Executors will typically store the task on the heap, usually by storing it in a `Box` or an `Arc`. When the executor picks a task for execution, it calls [`Spawn::poll_future_notify`][poll_future_notify]. This function ensures that the task context is set to the thread-local variable such that [`task::current`][current] is able to read it.
 
-When calling [`poll_future_notify`][poll_future_notify], the executor also
-passes in a notify handle and an identifier. These arguments are included in the
-task handle returned by [`task::current`][current] and are how the task is
-linked to the executor.
+When calling [`poll_future_notify`][poll_future_notify], the executor also passes in a notify handle and an identifier. These arguments are included in the task handle returned by [`task::current`][current] and are how the task is linked to the executor.
 
-The notify handle is an implementation of [`Notify`][`Notify`] and the identifier
-is a value that the executor uses to look up the current task. When
-[`Task::notify`][notify] is called, the [`notify`][Notify::notify] function on
-the notify handle is called with the supplied identifier. The implementation of
-this function is responsible for performing the scheduling logic.
+The notify handle is an implementation of [`Notify`][`Notify`] and the identifier is a value that the executor uses to look up the current task. When [`Task::notify`][notify] is called, the [`notify`][Notify::notify] function on the notify handle is called with the supplied identifier. The implementation of this function is responsible for performing the scheduling logic.
 
-One strategy for implementing an executor is to store each task in a `Box` and
-to use a linked list to track tasks that are scheduled for execution. When
-[`Notify::notify`][Notify::notify] is called, then the task associated with the
-identifier is pushed at the end of the `scheduled` linked list. When the
-executor runs, it pops from the front of the linked list and executes the task
-as described above.
+One strategy for implementing an executor is to store each task in a `Box` and to use a linked list to track tasks that are scheduled for execution. When [`Notify::notify`][Notify::notify] is called, then the task associated with the identifier is pushed at the end of the `scheduled` linked list. When the executor runs, it pops from the front of the linked list and executes the task as described above.
 
-Note that this section does not describe how the executor is run. The details of
-this are left to the executor implementation. One option is for the executor to
-spawn one or more threads and dedicate these threads to draining the `scheduled`
-linked list. Another is to provide a `MyExecutor::run` function that blocks the
-current thread and drains the `scheduled` linked list.
+Note that this section does not describe how the executor is run. The details of this are left to the executor implementation. One option is for the executor to spawn one or more threads and dedicate these threads to draining the `scheduled` linked list. Another is to provide a `MyExecutor::run` function that blocks the current thread and drains the `scheduled` linked list.
 
 [`current_thread`]: http://docs.rs/tokio-current-thread
 [`thread_pool`]: https://docs.rs/tokio-threadpool
@@ -364,34 +267,13 @@ current thread and drains the `scheduled` linked list.
 
 # Resources, drivers, and runtimes
 
-Resources are leaf futures, i.e. futures that are not implemented in terms of
-other futures. They are the types that use the task system described above to
-interact with the executor. Resource types include TCP and UDP sockets, timers,
-channels, file handles, etc. Tokio applications rarely need to implement
-resources. Instead, they use resources provided by Tokio or third party crates.
+Resources are leaf futures, i.e. futures that are not implemented in terms of other futures. They are the types that use the task system described above to interact with the executor. Resource types include TCP and UDP sockets, timers, channels, file handles, etc. Tokio applications rarely need to implement resources. Instead, they use resources provided by Tokio or third party crates.
 
-Oftentimes, a resource cannot function by itself and requires a driver. For
-example, Tokio TCP sockets are backed by a [`Reactor`]. The reactor is the
-socket resource driver. A single driver may power large numbers of resource
-instances. In order to use the resource, the driver must be running somewhere in
-the process. Tokio provides drivers for network resources ([`tokio-reactor`]),
-file resources ([`tokio-fs`]), and timers ([`tokio-timer`]). Providing decoupled
-driver components allows users to pick and choose which components they wish to
-use. Each driver can be used standalone or combined with other drivers.
+Oftentimes, a resource cannot function by itself and requires a driver. For example, Tokio TCP sockets are backed by a [`Reactor`]. The reactor is the socket resource driver. A single driver may power large numbers of resource instances. In order to use the resource, the driver must be running somewhere in the process. Tokio provides drivers for network resources ([`tokio-reactor`]), file resources ([`tokio-fs`]), and timers ([`tokio-timer`]). Providing decoupled driver components allows users to pick and choose which components they wish to use. Each driver can be used standalone or combined with other drivers.
 
-Because of this, in order to use Tokio and successfully execute tasks, an
-application must start an executor and the necessary drivers for the resources
-that the application's tasks depend on. This requires significant boilerplate.
-To manage the boilerplate, Tokio offers a couple of runtime options. A runtime
-is an executor bundled with all necessary drivers to power Tokio's resources.
-Instead of managing all the various Tokio components individually, a runtime is
-created and started in a single call.
+Because of this, in order to use Tokio and successfully execute tasks, an application must start an executor and the necessary drivers for the resources that the application's tasks depend on. This requires significant boilerplate. To manage the boilerplate, Tokio offers a couple of runtime options. A runtime is an executor bundled with all necessary drivers to power Tokio's resources. Instead of managing all the various Tokio components individually, a runtime is created and started in a single call.
 
-Tokio offers a [concurrent runtime][concurrent] and a
-[single-threaded][current_thread] runtimee. The concurrent runtime is backed by
-a multi-threaded, work-stealing executor. The single-threaded runtime executes
-all tasks and drivers on thee current thread. The user may pick the runtime with
-characteristics best suited for the application.
+Tokio offers a [concurrent runtime][concurrent] and a [single-threaded][current_thread] runtimee. The concurrent runtime is backed by a multi-threaded, work-stealing executor. The single-threaded runtime executes all tasks and drivers on thee current thread. The user may pick the runtime with characteristics best suited for the application.
 
 [`Reactor`]: https://docs.rs/tokio-reactor/0.1.5/tokio_reactor/
 [`tokio-reactor`]: https://docs.rs/tokio-reactor
@@ -402,19 +284,11 @@ characteristics best suited for the application.
 
 # Future
 
-As mentioned above, tasks are implemented using the [`Future`] trait. This trait
-is not limited to implementing tasks. A [`Future`] is a value that represents a
-non-blocking computation that will complete sometime in the future. A task is a
-computation with no output. Many resources in Tokio are represented with
-[`Future`] implementations. For example, a timeout is a [`Future`] that
-completes once the deadline has been reached.
+As mentioned above, tasks are implemented using the [`Future`] trait. This trait is not limited to implementing tasks. A [`Future`] is a value that represents a non-blocking computation that will complete sometime in the future. A task is a computation with no output. Many resources in Tokio are represented with [`Future`] implementations. For example, a timeout is a [`Future`] that completes once the deadline has been reached.
 
-The trait includes a number of combinators that are useful for working with
-future values.
+The trait includes a number of combinators that are useful for working with future values.
 
-Applications are built by either implementing `Future` for application specific
-types or defining application logic using combinators. Often, a mix of both
-strategies is most successful.
+Applications are built by either implementing `Future` for application specific types or defining application logic using combinators. Often, a mix of both strategies is most successful.
 
 <!-- TODO: Expand -->
 

--- a/content/docs/io/async_read_write.md
+++ b/content/docs/io/async_read_write.md
@@ -6,7 +6,6 @@ menu:
     parent: io
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/io/datagrams.md
+++ b/content/docs/io/datagrams.md
@@ -6,7 +6,6 @@ menu:
     parent: io
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/io/filesystem.md
+++ b/content/docs/io/filesystem.md
@@ -6,7 +6,6 @@ menu:
     parent: io
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -6,7 +6,6 @@ menu:
     parent: io
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/io/poll.md
+++ b/content/docs/io/poll.md
@@ -6,7 +6,6 @@ menu:
     parent: io
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/io/reading_writing_data.md
+++ b/content/docs/io/reading_writing_data.md
@@ -6,7 +6,6 @@ menu:
     parent: io
 ---
 
-This page has not been worked on yet. If you'd like to contribute visit the [doc-push]
-repo.
+This page has not been worked on yet. If you'd like to contribute visit the [doc-push] repo.
 
 [doc-push]: https://github.com/tokio-rs/doc-push

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -4,23 +4,15 @@ weight: 1
 menu: "docs"
 ---
 
-Tokio allows developers to write asynchronous programs in the Rust programming
-language. Instead of synchronously waiting for long-running operations like reading
-a file or waiting for a timer to complete before moving on to the next thing,
-Tokio allows developers to write programs where execution continues while the
-long-running operations are in progress.
+Tokio allows developers to write asynchronous programs in the Rust programming language. Instead of synchronously waiting for long-running operations like reading a file or waiting for a timer to complete before moving on to the next thing, Tokio allows developers to write programs where execution continues while the long-running operations are in progress.
 
-More specifically, Tokio is an event-driven, non-blocking I/O platform
-for writing asynchronous applications with Rust. At a high level, it
-provides a few major components:
+More specifically, Tokio is an event-driven, non-blocking I/O platform for writing asynchronous applications with Rust. At a high level, it provides a few major components:
 
 * A multithreaded, work-stealing based task [scheduler].
-* A [reactor] backed by the operating system's event queue (epoll, kqueue,
-  IOCP, etc...).
+* A [reactor] backed by the operating system's event queue (epoll, kqueue, IOCP, etc...).
 * Asynchronous [TCP and UDP][net] sockets.
 
-These components provide the runtime components necessary for building
-an asynchronous application.
+These components provide the runtime components necessary for building an asynchronous application.
 
 [net]: https://docs.rs/tokio/0.1/tokio/net/index.html
 [reactor]: https://docs.rs/tokio/0.1/tokio/reactor/index.html
@@ -28,44 +20,30 @@ an asynchronous application.
 
 # Fast
 
-Tokio is built on the Rust programming language, which is in of itself very
-fast. Applications built with Tokio will get those same benefits. Tokio's design
-is also geared towards enabling applications to be as fast as possible.
+Tokio is built on the Rust programming language, which is in of itself very fast. Applications built with Tokio will get those same benefits. Tokio's design is also geared towards enabling applications to be as fast as possible.
 
 ## Zero-cost abstractions
 
-Tokio is built around [futures]. Futures aren't a new idea, but the way Tokio
-uses them is [unique][poll]. Unlike futures from other languages, Tokio's
-futures compile down to a state machine. There is no added overhead from
-synchronization, allocation, or other costs common with future implementations.
+Tokio is built around [futures]. Futures aren't a new idea, but the way Tokio uses them is [unique][poll]. Unlike futures from other languages, Tokio's futures compile down to a state machine. There is no added overhead from synchronization, allocation, or other costs common with future implementations.
 
-Note that providing zero-cost abstractions does not mean that Tokio itself has
-no cost. It means that using Tokio results in an end product with equivalent
-overhead to not using Tokio.
+Note that providing zero-cost abstractions does not mean that Tokio itself has no cost. It means that using Tokio results in an end product with equivalent overhead to not using Tokio.
 
 [poll]: {{< ref "/docs/getting-started/runtime-model.md" >}}#polling-model
 [futures]: {{< ref "/docs/getting-started/futures.md" >}}
 
 ## Concurrency
 
-Out of the box, Tokio provides a multi-threaded, [work-stealing], scheduler. So,
-when you start the Tokio runtime, you are already using all of your computer's
-CPU cores.
+Out of the box, Tokio provides a multi-threaded, [work-stealing], scheduler. So, when you start the Tokio runtime, you are already using all of your computer's CPU cores.
 
-Modern computers increase their performance by adding cores, so being able to
-utilize many cores is critical for writing fast applications.
+Modern computers increase their performance by adding cores, so being able to utilize many cores is critical for writing fast applications.
 
 [work-stealing]: https://en.wikipedia.org/wiki/Work_stealing
 
 ## Non-blocking I/O
 
-When hitting the network, Tokio will used the most efficient system available to
-the operating system. On Linux this means [epoll], bsd platforms provide [kqueue],
-and Windows has [I/O completion ports][iocp].
+When hitting the network, Tokio will used the most efficient system available to the operating system. On Linux this means [epoll], bsd platforms provide [kqueue], and Windows has [I/O completion ports][iocp].
 
-This allows multiplexing many sockets on a single thread and receiving
-operating system notifications in batches, thus reducing system calls. All this
-leads to less overhead for the application.
+This allows multiplexing many sockets on a single thread and receiving operating system notifications in batches, thus reducing system calls. All this leads to less overhead for the application.
 
 [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
 [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
@@ -73,72 +51,44 @@ leads to less overhead for the application.
 
 # Reliable
 
-While Tokio cannot prevent all bugs, it is designed to minimize them. It does
-this by providing APIs that are hard to misuse. At the end of the day, you can
-ship applications to production with confidence.
+While Tokio cannot prevent all bugs, it is designed to minimize them. It does this by providing APIs that are hard to misuse. At the end of the day, you can ship applications to production with confidence.
 
 ## Ownership and type system
 
-Rust's ownership model and type system enables implementing system level
-applications without the fear of memory unsafety. It prevents classic bugs
-such as accessing uninitialized memory and use after free. It does this without
-adding any run-time overhead.
+Rust's ownership model and type system enables implementing system level applications without the fear of memory unsafety. It prevents classic bugs such as accessing uninitialized memory and use after free. It does this without adding any run-time overhead.
 
-Further, APIs are able to leverage the type system to provide hard to misuse
-APIs. For example, `Mutex` does not require the user to explicitly unlock.
+Further, APIs are able to leverage the type system to provide hard to misuse APIs. For example, `Mutex` does not require the user to explicitly unlock.
 
 ## Backpressure
 
-In push based systems, when a producer produces data faster than the consumer
-can process, data will start backing up. Pending data is stored in memory.
-Unless the producer stops producing, the system will eventually run out of
-memory and crash. The ability for a consumer to inform the producer to slow down
-is backpressure.
+In push based systems, when a producer produces data faster than the consumer can process, data will start backing up. Pending data is stored in memory. Unless the producer stops producing, the system will eventually run out of memory and crash. The ability for a consumer to inform the producer to slow down is backpressure.
 
-Because Tokio uses a [poll] based model, the problem mostly just goes away.
-Producers are lazy by default. They will not produce any data unless the
-consumer asks them to. This is built into Tokio's foundation.
+Because Tokio uses a [poll] based model, the problem mostly just goes away. Producers are lazy by default. They will not produce any data unless the consumer asks them to. This is built into Tokio's foundation.
 
 ## Cancellation
 
-Because of Tokio's [poll] based model, computations do no work unless they are
-polled. Dependents of that computation hold a [future][futures] representing the
-result of that computation. If the result is no longer needed, the future is
-dropped. At this point, the computation will no longer be polled and thus
-perform no more work.
+Because of Tokio's [poll] based model, computations do no work unless they are polled. Dependents of that computation hold a [future][futures] representing the result of that computation. If the result is no longer needed, the future is dropped. At this point, the computation will no longer be polled and thus perform no more work.
 
-Thanks to Rust's ownership model, the computation is able to implement `drop`
-handles to detect the future being dropped. This allows it to perform any
-necessary cleanup work.
+Thanks to Rust's ownership model, the computation is able to implement `drop` handles to detect the future being dropped. This allows it to perform any necessary cleanup work.
 
 # Lightweight
 
-Tokio scales well without adding overhead to the application, allowing it to
-thrive in resource constrained environments.
+Tokio scales well without adding overhead to the application, allowing it to thrive in resource constrained environments.
 
 ## No garbage collector
 
-Because Tokio is built on Rust, the compiled executable includes minimal
-language run-time. The end product is similar to what C++ would produce. This
-means, no garbage collector, no virtual machine, no JIT compilation, and no
-stack manipulation. Write your server applications without fear of
-[stop-the-world][gc] pauses.
+Because Tokio is built on Rust, the compiled executable includes minimal language run-time. The end product is similar to what C++ would produce. This means, no garbage collector, no virtual machine, no JIT compilation, and no stack manipulation. Write your server applications without fear of [stop-the-world][gc] pauses.
 
-It is possible to use Tokio without incurring any runtime allocations, making it
-a good fit for [real-time] use cases.
+It is possible to use Tokio without incurring any runtime allocations, making it a good fit for [real-time] use cases.
 
 [gc]: https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)#Disadvantages
 [real-time]: https://en.wikipedia.org/wiki/Real-time_computing
 
 ## Modular
 
-While Tokio provides a lot out of the box, it is all organized very modularly.
-Each component lives in a separate library. If needed, applications may opt to
-pick and choose the needed components and avoid pulling in the rest.
+While Tokio provides a lot out of the box, it is all organized very modularly. Each component lives in a separate library. If needed, applications may opt to pick and choose the needed components and avoid pulling in the rest.
 
-Tokio leverages [`mio`] for the system event queue and [`futures`] for defining
-tasks.  Tokio implements [async] syntax to improve readability of futures.
-[Many] libraries implement Tokio, including [`hyper`] and [`actix`].
+Tokio leverages [`mio`] for the system event queue and [`futures`] for defining tasks.  Tokio implements [async] syntax to improve readability of futures. [Many] libraries implement Tokio, including [`hyper`] and [`actix`].
 
 [`mio`]: https://carllerche.github.io/mio/mio/index.html
 [`futures`]: https://docs.rs/futures/*/futures/


### PR DESCRIPTION
This changes every markdown file (except `README.md`) to use soft instead of hard linebreaks (e.g all paragraphs are in one line). I saw in the issue that @rylev specified "documentation markdown files", however its a simple change to remove files from this PR.

PS! Going through the docs I found what seemed like a [invalid link](https://github.com/tokio-rs/website/compare/master...barskern:chore/change-to-soft-linebreaks?expand=1#diff-e806a3a3b56e46e79847fccefef92337R380) which I annotated with 'FIXME' 😄 

Closes: #230 

