### PR TITLE
Remove unnecessary port flag

### DIFF
--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -203,7 +203,7 @@ You can find the full example [here][full-code].
 command starts a listening TCP socket on the previously specified port.
 
 ```bash
-$ nc -l -p 6142
+$ nc -l 6142
 ```
 
 In a different terminal we'll run our project.


### PR DESCRIPTION
The `-p` flag conflicts with the `-l` flag and `nc` exits without binding to a port. 

The correct usage is `nc -l <some_port>`. 

As per the `nc` man pages: 

```
It is an error to use this option in conjunction with the -p, -s, or -z options.
```