### PR TITLE
Add newline so list renders correctly

### DIFF
--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -197,6 +197,7 @@ future like futures do. They rather keep yielding values over time.
 Just like futures, you can use streams to represent a wide range of things as long
 as those things produce discrete values at different points sometime in the future.
 For instance:
+
 * **UI Events** caused by the user interacting with a GUI in different ways. When an
   event happens the stream yields a different message to your app over time.
 * **Push Notifications from a server**. Sometimes a request/response model is not


### PR DESCRIPTION
This tiny PR adds a newline to get a bulleted list to render correctly in the [Streams Section of the Futures page](https://tokio.rs/docs/getting-started/futures/#streams).

### Current
![image](https://user-images.githubusercontent.com/933552/47955554-1149d400-df57-11e8-9092-eff2344041b4.png)

### With Change
![image](https://user-images.githubusercontent.com/933552/47955563-2161b380-df57-11e8-81b2-8bd805cb70bf.png)
