### PR TITLE
Shorten echo example output by skipping debug info

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -180,7 +180,7 @@ fn main() {
 
             // ... after which we'll print what happened.
             let handle_conn = bytes_copied.map(|amt| {
-                println!("wrote {:?} bytes", amt)
+                println!("wrote {:} bytes", amt.0)
             }).map_err(|err| {
                 eprintln!("IO error {:?}", err)
             });


### PR DESCRIPTION
Before:

```
wrote (4, ReadHalf { handle: BiLock { inner: Inner { state: 0, inner: Some(UnsafeCell) } } }, WriteHalf { handle: BiLock { inner: Inner { state: 0, inner: Some(UnsafeCell) } } }) bytes
```

After:

```
wrote 4 bytes
```

The latter seems like the intended outcome.