### PR TITLE
Clarify Box<Future<...> + Send> (doc-push #87)

### DIFF
--- a/content/docs/going-deeper/runtime-model.md
+++ b/content/docs/going-deeper/runtime-model.md
@@ -151,12 +151,12 @@ At the very simplest, an executor could look something like this:
 pub struct SpinExecutor {
     // the tasks an executor is responsible for in
     // a double ended queue
-    tasks: VecDeque<Box<Future<Item = (), Error = ()>>>,
+    tasks: VecDeque<Box<Future<Item = (), Error = ()> + Send>>,
 }
 
 impl SpinExecutor {
     pub fn spawn<T>(&mut self, task: T)
-    where T: Future<Item = (), Error = ()> + 'static
+    where T: Future<Item = (), Error = ()> + 'static + Send
     {
         self.tasks.push_back(Box::new(task));
     }

--- a/content/docs/going-deeper/timers.md
+++ b/content/docs/going-deeper/timers.md
@@ -77,7 +77,7 @@ use tokio::prelude::*;
 use std::time::{Duration, Instant};
 
 fn read_four_bytes(socket: TcpStream)
-    -> Box<Future<Item = (TcpStream, Vec<u8>), Error = ()>>
+    -> Box<Future<Item = (TcpStream, Vec<u8>), Error = ()> + Send>
 {
     let buf = vec![0; 4];
     let fut = io::read_exact(socket, buf)


### PR DESCRIPTION
This explicitly adds the Send trait to all boxed Future examples, and adds
some language to explain why. Also added another example of when Box is
required (trait definitions). Documentation on `impl Trait` is unfortunately sparse because it's a new feature in Rust, and having to box a return from a trait definition is where I personally ran into problems.

I strongly feel that `+ Send` should be the default for all boxed future examples, because forgetting it leads to serious headaches. (Honestly? We should patch futures to impl Send. But I'm new here.) Generally any example folks might copy-paste from should "just work". The rustdoc says to use `tokio::run` for handling execution in most cases, and by default Send is a requirement there.