### PR TITLE
fix (docs): adds url to Futures page from hello-world page

### DIFF
--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -221,6 +221,7 @@ We've only dipped our toes into Tokio and its asynchronous model. The next page 
 the guide will start digging a bit deeper into Futures and the Tokio runtime model.
 
 [`Future`]: {{< api-url "futures" >}}/future/trait.Future.html
+[`Futures`]: /docs/getting-started/futures/
 [rt]: {{< api-url "tokio" >}}/runtime/index.html
 [`io`]: {{< api-url "tokio" >}}/io/index.html
 [`net`]: {{< api-url "tokio" >}}/net/index.html


### PR DESCRIPTION
Minor fix, adds link to `Futrues` page in the tutorial/docs.