### PR TITLE
Fix broken links (issue #251)

### DIFF
--- a/content/blog/2017-03-tokio-io.md
+++ b/content/blog/2017-03-tokio-io.md
@@ -176,7 +176,7 @@ like the HTTP/2.0 protocol.
 
 [serde]: https://serde.rs/
 [tokio-serde-json]: https://github.com/carllerche/tokio-serde-json
-[`length_delimited::Framed`]: https://docs.rs/tokio-io/0.1/tokio_io/codec/length_delimited/struct.Framed.html
+[`length_delimited::Framed`]: https://docs.rs/tokio-io/0.1.6/tokio_io/codec/length_delimited/struct.Framed.html
 [`LengthFieldBasedFrameDecoder`]: https://netty.io/4.0/api/io/netty/handler/codec/LengthFieldBasedFrameDecoder.html
 
 ## What's next?
@@ -196,12 +196,12 @@ libraries as well. Finally we're looking to expand the middleware story in the
 near future with relation to both HTTP and generic [tokio-service]
 implementations. More on this coming soon!
 
-[`AsyncWrite::shutdown`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncWrite.html#tymethod.shutdown
+[`AsyncWrite::shutdown`]: https://docs.rs/tokio-io/0.1.6/tokio_io/trait.AsyncWrite.html#tymethod.shutdown
 [`close`]: https://docs.rs/futures/0.1/futures/sink/trait.Sink.html#method.close
 [`Bytes`]: http://carllerche.github.io/bytes/bytes/struct.Bytes.html
 [`BytesMut`]: http://carllerche.github.io/bytes/bytes/struct.BytesMut.html
-[`read_buf`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncRead.html#method.read_buf
-[`write_buf`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncWrite.html#method.write_buf
+[`read_buf`]: https://docs.rs/tokio-io/0.1.6/tokio_io/trait.AsyncRead.html#method.read_buf
+[`write_buf`]: https://docs.rs/tokio-io/0.1.6/tokio_io/trait.AsyncWrite.html#method.write_buf
 [`Buf`]: http://carllerche.github.io/bytes/bytes/trait.Buf.html
 [`BufMut`]: http://carllerche.github.io/bytes/bytes/trait.BufMut.html
 [crates.io]: https://crates.io
@@ -211,19 +211,19 @@ implementations. More on this coming soon!
 [tokio-service]: https://crates.io/crates/tokio-service
 [tokio-proto]: https://crates.io/crates/tokio-proto
 [bytes]: https://crates.io/crates/bytes
-[`tokio_core::io`]: https://docs.rs/tokio-core/0.1/tokio_core/io/
-[`Io`]: https://docs.rs/tokio-core/0.1/tokio_core/io/trait.Io.html
-[`Codec`]: https://docs.rs/tokio-core/0.1/tokio_core/io/trait.Codec.html
+[`tokio_core::io`]: https://docs.rs/tokio-core/0.1.9/tokio_core/io/
+[`Io`]: https://docs.rs/tokio-core/0.1.9/tokio_core/io/trait.Io.html
+[`Codec`]: https://docs.rs/tokio-core/0.1.9/tokio_core/io/trait.Codec.html
 [`Stream`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html
 [`Sink`]: https://docs.rs/futures/0.1/futures/sink/trait.Sink.html
 [`std::io`]: https://doc.rust-lang.org/std/io/
-[`AsyncWrite`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncWrite.html
-[`AsyncRead`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncRead.html
-[`split`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncRead.html#method.split
-[`Encoder`]: https://docs.rs/tokio-io/0.1/tokio_io/codec/trait.Encoder.html
-[`Decoder`]: https://docs.rs/tokio-io/0.1/tokio_io/codec/trait.Decoder.html
-[`EasyBuf`]: https://docs.rs/tokio-core/0.1/tokio_core/io/struct.EasyBuf.html
-[`length_delimited`]: https://docs.rs/tokio-io/0.1/tokio_io/codec/length_delimited/index.html
+[`AsyncWrite`]: https://docs.rs/tokio-io/0.1.6/tokio_io/trait.AsyncWrite.html
+[`AsyncRead`]: https://docs.rs/tokio-io/0.1.6/tokio_io/trait.AsyncRead.html
+[`split`]: https://docs.rs/tokio-io/0.1.6/tokio_io/trait.AsyncRead.html#method.split
+[`Encoder`]: https://docs.rs/tokio-io/0.1.6/tokio_io/codec/trait.Encoder.html
+[`Decoder`]: https://docs.rs/tokio-io/0.1.6/tokio_io/codec/trait.Decoder.html
+[`EasyBuf`]: https://docs.rs/tokio-core/0.1.9/tokio_core/io/struct.EasyBuf.html
+[`length_delimited`]: https://docs.rs/tokio-io/0.1.6/tokio_io/codec/length_delimited/index.html
 [closing]: https://github.com/tokio-rs/tokio-core/issues/61#issuecomment-277568977
 [tokio-serde-json]: https://github.com/carllerche/tokio-serde-json
 [sean]: https://github.com/seanmonstar

--- a/content/blog/2018-02-tokio-reform-shipped.md
+++ b/content/blog/2018-02-tokio-reform-shipped.md
@@ -105,7 +105,7 @@ of the [Conduit] project.
 
 [reform RFC]: https://github.com/tokio-rs/tokio-rfcs/blob/master/text/0001-tokio-reform.md
 [crates.io]: https://crates.io/crates/tokio
-[`current_thread`]: {{< api-url "tokio" >}}/executor/current_thread/index.html
+[`current_thread`]: https://docs.rs/tokio-current-thread
 [`tokio-io`]: https://github.com/tokio-rs/tokio-io
 [`futures`]: https://github.com/rust-lang-nursery/futures-rs
 [`mio`]: https://github.com/carllerche/mio

--- a/content/blog/2018-03-timers.md
+++ b/content/blog/2018-03-timers.md
@@ -62,8 +62,8 @@ As mentioned above, the API has not really changed. There are three primary
 types:
 
 * [`Delay`][delay]: A future that completes at a set instant in time.
-* [`Deadline`][deadline]: Decorates a future ensuring it completes before the
-  deadline is reached.
+* [`Timeout`][timeout]: Decorates a future ensuring it completes before the
+  timeout is reached.
 * [`Interval`][interval]: A stream that yields values at a fixed intervals.
 
 And a quick example:
@@ -110,7 +110,7 @@ directly, a thread pool is started. Each worker thread will get one timer
 instance. So, this means that if the runtime starts 4 worker threads, there will
 be 4 timer instances, one per thread. Doing this allows using the timer without
 paying a synchronization cost since the timer will be located on the same thread
-as the code that uses the various timer types (`Delay`, `Deadline`, `Interval`).
+as the code that uses the various timer types (`Delay`, `Timeout`, `Interval`).
 
 And with that, have a great weekend!
 
@@ -120,7 +120,7 @@ And with that, have a great weekend!
 [wheel]: http://www.cs.columbia.edu/~nahum/w6998/papers/sosp87-timing-wheels.pdf
 [2]: https://crates.io/crates/tokio-timer/0.2.0
 [delay]: https://docs.rs/tokio/0.1/tokio/timer/struct.Delay.html
-[deadline]: https://docs.rs/tokio/0.1/tokio/timer/struct.Deadline.html
+[timeout]: https://docs.rs/tokio/0.1/tokio/timer/struct.Timeout.html
 [interval]: https://docs.rs/tokio/0.1/tokio/timer/struct.Interval.html
 [guide]: {{< ref "/docs/going-deeper/timers.md" >}}
 [api]: https://docs.rs/tokio/0.1/tokio/timer/index.html

--- a/content/docs/getting-started/echo.md
+++ b/content/docs/getting-started/echo.md
@@ -183,6 +183,6 @@ The full code can be found [here][full-code].
 
 [full-code]: https://github.com/tokio-rs/tokio/blob/master/examples/echo.rs
 [hello world]: {{< ref "/docs/getting-started/hello-world.md" >}}
-[`io::copy`]: {{< api-url "tokio-io" >}}/fn.copy.html
-[`split`]: {{< api-url "tokio-io" >}}/trait.AsyncRead.html#method.split
+[`io::copy`]: {{< api-url "tokio" >}}/io/fn.copy.html
+[`split`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html#method.split
 [`tokio::spawn`]: {{< api-url "tokio-executor" >}}/fn.spawn.html

--- a/content/docs/getting-started/runtime.md
+++ b/content/docs/getting-started/runtime.md
@@ -88,7 +88,7 @@ run inner future.
 In the next section, we'll take a look at a more involved example than our hello-
 world example that takes everything we've learned so far into account.
 
-[`CurrentThread`]: {{< api-url "tokio" >}}/executor/current_thread/index.html
+[`CurrentThread`]: https://docs.rs/tokio-current-thread
 [`ThreadPool`]: http://docs.rs/tokio-threadpool
 [rt]: {{< api-url "tokio" >}}/runtime/index.html
 [Go’s goroutine]: https://www.golang-book.com/books/intro/10

--- a/content/docs/going-deeper/building-runtime.md
+++ b/content/docs/going-deeper/building-runtime.md
@@ -187,5 +187,5 @@ also `executor.run` which can be executed afterwards.
 [`Park`]: {{< api-url "tokio-executor" >}}/park/trait.Park.html
 [`Reactor`]: {{< api-url "tokio" >}}/reactor/struct.Reactor.html
 [mio]: https://crates.io/crates/mio
-[`CurrentThread`]: {{< api-url "tokio" >}}/executor/current_thread/struct.CurrentThread.html
-[`Timer`]: {{< api-url "tokio-timer" >}}/timer/struct.Timer.html
+[`CurrentThread`]: https://docs.rs/tokio-current-thread/0.1.4/tokio_current_thread/struct.CurrentThread.html
+[`Timer`]: {{< api-url "tokio-timer" >}}/tokio_timer/timer/struct.Timer.html

--- a/content/docs/going-deeper/runtime-model.md
+++ b/content/docs/going-deeper/runtime-model.md
@@ -231,7 +231,7 @@ core of the [`futures`] task model.
 [`TcpStream`]: {{< api-url "tokio" >}}/net/struct.TcpStream.html
 [`Async`]: {{< api-url "futures" >}}/enum.Async.html
 [`Future`]: {{< api-url "futures" >}}/future/trait.Future.html
-[`CurrentThread`]: {{< api-url "tokio" >}}/executor/current_thread/index.html
+[`CurrentThread`]: https://docs.rs/tokio-current-thread
 [`ThreadPool`]: http://docs.rs/tokio-threadpool
 [rt]: {{< api-url "tokio" >}}/runtime/index.html
 [next section]: {{< ref "/docs/getting-started/futures.md#returning-not-ready" >}}


### PR DESCRIPTION
Fixes broken links from #251.

Links in [content/blog/2017-03-tokio-io.md](https://github.com/tokio-rs/website/compare/master...vokar97:fix-broken-links?expand=1#diff-a589021cf16a73f77248a6c5a0c762d6) point to specific versions containing required traits, structs and functions, since otherwise the blog post may be hard to understand.