### PR TITLE
Update broken link for "CurrentThread"

### DIFF
--- a/content/docs/getting-started/runtime.md
+++ b/content/docs/getting-started/runtime.md
@@ -88,7 +88,7 @@ run inner future.
 In the next section, we'll take a look at a more involved example than our hello-
 world example that takes everything we've learned so far into account.
 
-[`CurrentThread`]: {{< api-url "tokio" >}}/executor/current_thread/index.html
+[`CurrentThread`]: {{< api-url "tokio" >}}/runtime/current_thread/index.html
 [`ThreadPool`]: http://docs.rs/tokio-threadpool
 [rt]: {{< api-url "tokio" >}}/runtime/index.html
 [Go’s goroutine]: https://www.golang-book.com/books/intro/10


### PR DESCRIPTION
It appears that this submodule has moved from `executor` to `runtime`.  I have updated the link.

My two cents:
* Change the template url to be fixed to a minor version (e.g. 0.1.0 instead of 0.1)
* Add to the CI tests a script which tries to resolve links, and fails on 404 receipt

I'm happy to have a go at the script if anybody's interested