### PR TITLE
Fix typo

### DIFF
--- a/content/docs/futures/basic.md
+++ b/content/docs/futures/basic.md
@@ -22,7 +22,7 @@ trait Future {
     /// The type representing errors that occurred while processing the computation.
     type Error;
 
-    /// The function that will be repeatedly called to see if the future is
+    /// The function that will be repeatedly called to see if the future
     /// has completed or not. The `Async` enum can either be `Ready` or
     /// `NotReady` and indicates whether the future is ready to produce
     /// a value or not.


### PR DESCRIPTION
I believe there is a typo in the [Implementing futures](https://tokio.rs/docs/futures/basic/) page. So here is the fix 👍 