### PR TITLE
fix urls to tokio examples

### DIFF
--- a/content/docs/getting-started/echo.md
+++ b/content/docs/getting-started/echo.md
@@ -181,7 +181,7 @@ concurrently!
 
 The full code can be found [here][full-code].
 
-[full-code]: https://github.com/tokio-rs/tokio/blob/master/examples/echo.rs
+[full-code]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/echo.rs
 [hello world]: {{< ref "/docs/getting-started/hello-world.md" >}}
 [`io::copy`]: {{< api-url "tokio" >}}/io/fn.copy.html
 [`split`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html#method.split

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -229,6 +229,6 @@ the guide will start digging a bit deeper into Futures and the Tokio runtime mod
 [`io`]: {{< api-url "tokio" >}}/io/index.html
 [`net`]: {{< api-url "tokio" >}}/net/index.html
 [`io::write_all`]: {{< api-url "tokio-io" >}}/io/fn.write_all.html
-[full-code]: https://github.com/tokio-rs/tokio/blob/master/examples/hello_world.rs
+[full-code]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/hello_world.rs
 [Netcat]: http://netcat.sourceforge.net/
 [Nmap.org]: https://nmap.org

--- a/content/docs/going-deeper/chat.md
+++ b/content/docs/going-deeper/chat.md
@@ -772,7 +772,7 @@ types without reaching for trait objects.
 
 The full code can be found [here][full-code].
 
-[full-code]: https://github.com/tokio-rs/tokio/blob/master/examples/chat.rs
+[full-code]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/chat.rs
 [Hello World!]: {{< ref "/docs/getting-started/hello-world.md" >}}
 [message passing]: {{< ref "/docs/going-deeper/tasks.md#message-passing" >}}
 [mpsc]: {{< api-url "futures" >}}/sync/mpsc/index.html


### PR DESCRIPTION
blob/master/examples to blob/master/tokio/examples