### PR TITLE
Update all links to tokio examples directory

### DIFF
--- a/content/blog/2018-03-tokio-runtime.md
+++ b/content/blog/2018-03-tokio-runtime.md
@@ -42,7 +42,7 @@ reading all data from the socket and writing it back to the same socket.
 The [guides] and [examples] have been updated to use the runtime.
 
 [guides]: https://tokio.rs/docs/getting-started/hello-world/
-[examples]: https://github.com/tokio-rs/tokio/tree/master/examples
+[examples]: https://github.com/tokio-rs/tokio/tree/master/tokio/examples
 
 ## What is the Tokio Runtime?
 

--- a/content/docs/getting-started/echo.md
+++ b/content/docs/getting-started/echo.md
@@ -181,7 +181,7 @@ concurrently!
 
 The full code can be found [here][full-code].
 
-[full-code]: https://github.com/tokio-rs/tokio/blob/master/examples/echo.rs
+[full-code]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/echo.rs
 [hello world]: {{< ref "/docs/getting-started/hello-world.md" >}}
 [`io::copy`]: {{< api-url "tokio" >}}/io/fn.copy.html
 [`split`]: {{< api-url "tokio" >}}/io/trait.AsyncRead.html#method.split

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -229,6 +229,6 @@ the guide will start digging a bit deeper into Futures and the Tokio runtime mod
 [`io`]: {{< api-url "tokio" >}}/io/index.html
 [`net`]: {{< api-url "tokio" >}}/net/index.html
 [`io::write_all`]: {{< api-url "tokio-io" >}}/io/fn.write_all.html
-[full-code]: https://github.com/tokio-rs/tokio/blob/master/examples/hello_world.rs
+[full-code]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/hello_world.rs
 [Netcat]: http://netcat.sourceforge.net/
 [Nmap.org]: https://nmap.org

--- a/content/docs/going-deeper/building-runtime.md
+++ b/content/docs/going-deeper/building-runtime.md
@@ -18,7 +18,7 @@ more complex, but there are more moving parts around. Knowing the details here
 can be a stepping stone to reading the code of the default runtime.
 
 A complete, working example of things discussed here can be found in the
-[git repository](https://github.com/tokio-rs/tokio/tree/master/examples/manual-runtime.rs).
+[git repository](https://github.com/tokio-rs/tokio/tree/master/tokio/examples/manual-runtime.rs).
 
 # The `Park` trait
 

--- a/content/docs/going-deeper/chat.md
+++ b/content/docs/going-deeper/chat.md
@@ -772,7 +772,7 @@ types without reaching for trait objects.
 
 The full code can be found [here][full-code].
 
-[full-code]: https://github.com/tokio-rs/tokio/blob/master/examples/chat.rs
+[full-code]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/chat.rs
 [Hello World!]: {{< ref "/docs/getting-started/hello-world.md" >}}
 [message passing]: {{< ref "/docs/going-deeper/tasks.md#message-passing" >}}
 [mpsc]: {{< api-url "futures" >}}/sync/mpsc/index.html

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -124,4 +124,4 @@ More examples can be found [here][examples].
 [TCP]: {{< api-url "tokio" >}}/net/tcp/index.html
 [UDP]: {{< api-url "tokio" >}}/net/udp/index.html
 [Unix]: {{< api-url "tokio" >}}/net/unix/index.html
-[examples]: https://github.com/tokio-rs/tokio/tree/master/examples
+[examples]: https://github.com/tokio-rs/tokio/tree/master/tokio/examples

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -194,4 +194,4 @@ fn main() {
 }
 ```
 
-More examples can be found [here](https://github.com/tokio-rs/tokio/tree/master/examples).
+More examples can be found [here](https://github.com/tokio-rs/tokio/tree/master/tokio/examples).

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -128,7 +128,7 @@
     <ul class="tk-footer-links">
       <li><a href="https://github.com/tokio-rs/tokio">GitHub</a></li>
       <li><a href="https://twitter.com/tokio_rs">Twitter</a></li>
-      <li><a href="https://github.com/tokio-rs/tokio/tree/master/examples">Examples</a></li>
+      <li><a href="https://github.com/tokio-rs/tokio/tree/master/tokio/examples">Examples</a></li>
       <li><a href="/docs/overview/">About</a></li>
       <li><a href="/gsoc/">GSoC</a></li>
     </ul>


### PR DESCRIPTION
Some links to tokio examples became outdated, fixed it in both docs and blog posts.