### PR TITLE
Improvement/clarification to points related to overview of futures

### DIFF
--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -81,8 +81,8 @@ of basic I/O, you can use a future to represent a wide range of events, e.g.:
 * **An RPC invocation** to a server. When the server replies, the future is
   completed, and its value is the server’s response.
 
-* **A timeout**. When time is up, the future is completed, and its value is
-  `()`.
+* **A timeout**. When time is up, the future is completed, the value is an empty tuple
+  `()` (also referred to as "unit" or "the unit type").
 
 * **A long-running CPU-intensive task**, running on a thread pool. When the task
   finishes, the future is completed, and its value is the return value of the


### PR DESCRIPTION
In PR #301, I proposed a minor clarification to the point on timeouts

Since the same listing of points is reused, I propose applying the same
clarification as outlined in PR #301.

The same listing is used at:

- https://tokio.rs/docs/futures/overview/ (PR #301)
- https://tokio.rs/docs/getting-started/futures/

Explanation lifted from #301:

> The single bullet in the overview kind of stand out as being very
> _technical_ compared to the others and it does not clarify the
> subtleties of the `()`. As a *Rust* _n00b_ I found this confusing,
> since the abstraction level in the documentation is not consistent.