### PR TITLE
Fix a grammatical error

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,7 +34,7 @@
 
     <p>
       Building on top of Rust, Tokio provides blazingly fast performance,
-      making it an ideal for high performance server applications.
+      making it an ideal choice for high performance server applications.
     </p>
 
     <p>


### PR DESCRIPTION
Per title. Alternative: drop "an"