### PR TITLE
Make futures crate usage consistent in echo server

### DIFF
--- a/content/docs/getting-started/echo.md
+++ b/content/docs/getting-started/echo.md
@@ -30,6 +30,7 @@ Next, add the necessary dependencies:
 ```toml
 [dependencies]
 tokio = "0.1"
+# futures = "0.1"
 ```
 
 and the crates and types into scope in `main.rs`:
@@ -37,7 +38,7 @@ and the crates and types into scope in `main.rs`:
 ```rust
 # #![deny(deprecated)]
 extern crate tokio;
-extern crate futures;
+# extern crate futures;
 
 use tokio::io;
 use tokio::net::TcpListener;


### PR DESCRIPTION
The `futures` crate isn't used in any of the visible portion on the tokio.rs
site, so the extern crate declaration should be commented out from the code
samples.

Also, since the crate is used in the commented out portion of the code, it
should also be added to Cargo.toml, but commented out.