### PR TITLE
Fix example for chaining calls to and_then

### DIFF
--- a/content/docs/futures/combinators.md
+++ b/content/docs/futures/combinators.md
@@ -175,7 +175,8 @@ fn main() {
         .and_then(|(socket, buf)| {
             println!("got {:?}", buf);
             Ok(())
-        });
+        })
+        .map_err(|_| println!("failed"));
 
 # let future = futures::future::ok::<(), ()>(());
     tokio::run(future);


### PR DESCRIPTION
The example code was lacking an adapter to changefrom the future type returned by
the chained and_then calls to the future type that is expected by tokio::run.

Fixes: #308