### PR TITLE
Fix typos in combinators.md

### DIFF
--- a/content/docs/futures/combinators.md
+++ b/content/docs/futures/combinators.md
@@ -117,7 +117,7 @@ The `and_then` combinator allows sequencing two asynchronous operations. Once
 the first operation completes, the value is passed to a function. The function
 uses that value to produce a new future and that future is then executed. The
 difference between `and_then` and `map` is that `and_then`'s function returns a
-future where as `map`'s function returns a value.
+future whereas `map`'s function returns a value.
 
 The original implementation is found [here][connect-and-write]. Once updated to
 use combinators, it becomes:

--- a/content/docs/futures/combinators.md
+++ b/content/docs/futures/combinators.md
@@ -493,7 +493,7 @@ This ensures that the function has a single return type: `Either`.
 In situations where there are more than two branches, `Either` enums must be
 nested (`Either<Either<A, B>, C>`) or a custom, multi variant, enum is defined.
 
-This scenario comes up often when trying to conditional return errors.
+This scenario comes up often when trying to conditionally return errors.
 Consider:
 
 ```rust


### PR DESCRIPTION
"trying to conditional return errors" => "trying to conditionally return errors"
"where as" => "whereas"