### PR TITLE
Added usage example for custom LinesCodec

### DIFF
--- a/content/docs/io/reading_writing_data.md
+++ b/content/docs/io/reading_writing_data.md
@@ -390,6 +390,28 @@ impl Decoder for LinesCodec {
 # fn main() {}
 ```
 
+To use our custom `LinesCodec`, we need to frame incoming data using [`Framed::new`]:
+
+````rust
+use tokio::codec::Framed;
+
+# fn main() {
+# let addr = "127.0.0.1:12345".parse().unwrap();
+let lines_fut = TcpStream::connect(&addr).and_then(|stream| {
+    // Frame the input with our codec...
+    let transport = Framed::new(stream, LinesCodec);
+
+    // ...then print each framed line
+    transport.for_each(|line| {
+        println!("Next line: {}", line);
+        Ok(())
+    })
+})
+.map_err(|e| eprintln!("socket error: {}", e));
+
+tokio::run(lines_fut);
+```
+
 [the overview]: {{< ref "/docs/io/overview.md" >}}
 [the next section]: {{< ref "/docs/io/async_read_write.md" >}}
 [echo server]: {{< ref "/docs/io/overview.md" >}}#an-example-server

--- a/content/docs/io/reading_writing_data.md
+++ b/content/docs/io/reading_writing_data.md
@@ -302,7 +302,7 @@ exists):
 # extern crate tokio;
 extern crate bytes;
 use bytes::{BufMut, BytesMut};
-use tokio::codec::{Decoder, Encoder};
+use tokio::codec::{Decoder, Encoder, Framed};
 use tokio::prelude::*;
 
 // This is where we'd keep track of any extra book-keeping information
@@ -387,16 +387,12 @@ impl Decoder for LinesCodec {
         })
     }
 }
-# fn main() {}
-```
 
-To use our custom `LinesCodec`, we need to frame incoming data using [`Framed::new`]:
-
-````rust
-use tokio::codec::Framed;
 
 # fn main() {
 # let addr = "127.0.0.1:12345".parse().unwrap();
+
+// To use our custom LinesCodec, we need to frame incoming data using Framed::new
 let lines_fut = TcpStream::connect(&addr).and_then(|stream| {
     // Frame the input with our codec...
     let transport = Framed::new(stream, LinesCodec);
@@ -410,6 +406,7 @@ let lines_fut = TcpStream::connect(&addr).and_then(|stream| {
 .map_err(|e| eprintln!("socket error: {}", e));
 
 tokio::run(lines_fut);
+# }
 ```
 
 [the overview]: {{< ref "/docs/io/overview.md" >}}


### PR DESCRIPTION
When finishing this chapter, I was confused as to how exactly I could use the created `LinesCodec`.

I found the relevant information a few chapters further in [Going Deeper - Frames](https://tokio.rs/docs/going-deeper/frames/#using-a-codec)

Now, a stripped down version of the information is part of the example to tie both chapters together.