### PR TITLE
idea: 0.2 version branch with different header color

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,8 @@ menu:
 
 
 params:
+  version: "0.2.0-alpha.6"
+  status: "alpha"
   tokioDocsURL: "https://docs.rs/tokio/0.1/tokio"
   tokioExecutorDocsURL: "https://docs.rs/tokio-executor/0.1/tokio_executor"
   tokioIoDocsURL: "https://docs.rs/tokio-io/0.1/tokio_io"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -33,12 +33,16 @@
       {{ end }}
     </title>
   </head>
-  <body>
+  <body class="{{ .Site.Params.Status }}">
     <header class="navbar navbar-expand navbar-dark flex-column flex-md-row tk-navbar">
       <a class="navbar-brand" href="/">
         <img src="/img/Tokio_Mark_White.png" class="align-middle" alt="">
       </a>
       <div class="collapse navbar-collapse">
+        {{ if eq .Site.Params.Status "alpha"}}
+          <p class="warn">Update in-progress, may be incorrect and incomplete</p>
+          <p class="version">{{.Site.Params.Version}}</p>
+        {{ end }}
         <ul class="navbar-nav">
           <li class="nav-item">
             <a class="nav-link {{ if .IsHome }} active {{ end }}" href="/">Home</a>

--- a/static/css/tokio.css
+++ b/static/css/tokio.css
@@ -55,6 +55,27 @@ img {
   z-index: 1071;
 }
 
+.alpha .tk-navbar {
+  background-color: #db9900;
+}
+.alpha p {
+  color: #fff;
+  font-size: small;
+  padding: 0px;
+  margin: 0px;
+}
+.alpha  .warn {
+    position: absolute;
+    top: 1px;
+    left: 82px;
+}
+.alpha .version {
+    position: absolute;
+    top: 1px;
+    right: 20px;
+}
+
+
 .tk-navbar .navbar-nav-svg {
   display: inline-block;
   width: 1rem;


### PR DESCRIPTION
I was taking a look at https://github.com/tokio-rs/website/pull/352 and 
looking at where to add https://github.com/tokio-rs/doc-push/issues/98

I think it will help working on 0.2 docs to have a in-progress version posted somewhere
that is visually different from the current / full-tested docs.  

This is a suggestion to have a different header color in a branch and collect 0.2 changes together