### PR TITLE
Fix Linkerd link

### DIFF
--- a/content/blog/2019-11-tokio-0-2.md
+++ b/content/blog/2019-11-tokio-0-2.md
@@ -145,7 +145,7 @@ the cut for this release, but will happen soon!
 * [@piscisaureus](https://github.com/piscisaureus)
 * [@Thomasdezeeuw](https://github.com/Thomasdezeeuw)
 
-And a big thanks to [Buoyant], the makers of [Linkerd] (the proxy is written in
+And a big thanks to [Buoyant], the makers of [Linkerd] \(the proxy is written in
 Rust), who sponsored most of the work.
 
 [Buoyant]: https://buoyant.io/


### PR DESCRIPTION
This is an attempt to fix a link that is being rendered incorrectly on <https://tokio.rs/blog/2019-11-tokio-0-2/>. The Markdown renders fine on GitHub before and after the change. I didn't check how Hugo renders it after this change, so you will want to do that.