### PR TITLE
Fix: 2 relevant lines not shown on website

### DIFF
--- a/content/docs/getting-started/echo.md
+++ b/content/docs/getting-started/echo.md
@@ -124,7 +124,7 @@ Let's take a look at the connection accept code again.
 ```rust
 # #![deny(warnings)]
 # use std::env;
-# use futures::prelude::*;
+use futures::StreamExt;
 # use tokio::net::TcpListener;
 # #[tokio::main]
 # async fn main() {
@@ -134,7 +134,7 @@ Let's take a look at the connection accept code again.
 #     .await
 #     .expect("unable to bind TCP listener");
 #
-# let mut incoming = listener.incoming();
+let mut incoming = listener.incoming();
 let server = {
   async move {
     while let Some(conn) = incoming.next().await {


### PR DESCRIPTION
The 2 lines:
let mut incoming = listener.incoming();
use futures::prelude::*; (or better just: use futures::StreamExt; )
are needed to compile the example but weren't published on the website. I removed the comments and change futures::prelude to use futures::StreamExt; 

As the linked example at the end is different, the 2 lines are relevant to understand the example.