### PR TITLE
blog: fix date and weight for tokio-compat announcement

### DIFF
--- a/content/blog/2019-12-compat.md
+++ b/content/blog/2019-12-compat.md
@@ -1,9 +1,9 @@
 +++
-date = "2019-12-17"
+date = "2019-12-18"
 title = "Announcing Tokio-Compat"
-description = "December 17, 2019"
+description = "December 18, 2019"
 menu = "blog"
-weight = 984
+weight = 983
 +++
 
 The [release][release-02] of Tokio 0.2 was the culmination of a great deal of


### PR DESCRIPTION
The date accidentally said the post was published yesterday, but it went live
today. The old weight would have placed it after the Mio announcement
rather than before. Now they will appear in chronological order.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>