### PR TITLE
blog: fix links in tokio-compat announcement

### DIFF
--- a/content/blog/2019-12-compat.md
+++ b/content/blog/2019-12-compat.md
@@ -221,6 +221,7 @@ has the benefit of resulting in more idiomatic, readable, and maintainable code.
 For most projects, switching to use async/await syntax is the recommended
 migration path.
 
+[runtimes]: https://docs.rs/tokio-compat/0.1.0/tokio_compat/runtime/index.html
 [`Runtime`]: https://docs.rs/tokio-compat/0.1.0/tokio_compat/runtime/struct.Runtime.html
 [spawning]: https://docs.rs/tokio-compat/0.1.0/tokio_compat/runtime/index.html#spawning
 [`pin-project`]: https://crates.io/crates/pin-project

--- a/content/blog/2019-12-compat.md
+++ b/content/blog/2019-12-compat.md
@@ -99,6 +99,7 @@ tokio_compat::run_std(async {
 [await]: ../2019-11-tokio-0-2/#async-await
 [10x]: ../2019-10-scheduler/
 [challenging]: https://users.rust-lang.org/t/failed-to-port-mononoke-to-tokio-0-2-experience-report/32478
+[futures-compat]: https://docs.rs/futures/0.3.1/futures/compat/index.html
 
 ## Using `tokio-compat`
 


### PR DESCRIPTION
This link was missing a reference. This fixes it.

Thanks to @davidbarsky for catching this one!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>