### PR TITLE
Fix typo in spawning.md

### DIFF
--- a/content/docs/futures/spawning.md
+++ b/content/docs/futures/spawning.md
@@ -432,7 +432,7 @@ tokio::run(lazy(|| {
 # When not to spawn tasks
 
 If the amount of coordination via message passing and synchronization primitives
-outweighs the parallism benefits from spawning tasks, then maintaining a single
+outweighs the parallelism benefits from spawning tasks, then maintaining a single
 task is preferred.
 
 For example, it is generally better to maintain reading from and writing to a


### PR DESCRIPTION
Tiny typo. `s/parallism/parallelism/`.