### PR TITLE
Add example about futures that must be polled (runtime.md)

### DIFF
--- a/content/docs/getting-started/runtime.md
+++ b/content/docs/getting-started/runtime.md
@@ -22,13 +22,38 @@ distributes load across multiple threads. The `threaded_scheduler` is the
 default for applications and the `basic_scheduler` is the default for tests.
 
 It's important to remember that all async tasks **must** be spawned on the
-runtime or no work will be performed.
+runtime or no work will be performed:
+
+```rust
+# #![allow(unused_must_use)]
+use tokio::net::TcpStream;
+
+#[tokio::main]
+async fn main() {
+  // Create a tcp stream, but do not call await.
+  TcpStream::connect("127.0.0.1:6142");
+}
+```
+
+This code will do nothing while the compiler produces the warning below, reminding you
+that the future must be awaited in order for it to be executed.
+
+```text
+warning: unused implementer of `std::future::Future` that must be used
+ --> src/main.rs:6:3
+  |
+6 |   TcpStream::connect("127.0.0.1:6142");
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_must_use)]` on by default
+  = note: futures do nothing unless you `.await` or poll them
+```
 
 ## Spawning Tasks
 
 One of the unique aspects of Tokio is that futures can be spawned on the runtime
 from within other async tasks. Tasks are the application’s “unit of logic”.
-They are similar to [Go’s goroutine] and [Erlang’s process], but asynchronous.
+They are similar to [Go's goroutine] and [Erlang's process], but asynchronous.
 In other words, tasks are asynchronous green threads.
 
 Tasks are passed to the runtime, which handle scheduling the task. The runtime
@@ -63,6 +88,8 @@ stream we'll simply run inner future.
 In the next section, we'll take a look at a more involved example than our hello-
 world example that takes everything we've learned so far into account.
 
+[Go's goroutine]: https://www.golang-book.com/books/intro/10
+[Erlang's process]: http://erlang.org/doc/reference_manual/processes.html
 [`Runtime`]: https://docs.rs/tokio/0.2/tokio/runtime/struct.Runtime.html
 [`basic_scheduler`]: https://docs.rs/tokio/0.2/tokio/runtime/struct.Builder.html#method.basic_scheduler
 [`threaded_scheduler`]: https://docs.rs/tokio/0.2/tokio/runtime/struct.Builder.html#method.threaded_scheduler

--- a/content/docs/getting-started/runtime.md
+++ b/content/docs/getting-started/runtime.md
@@ -35,7 +35,7 @@ async fn main() {
 }
 ```
 
-This code will do nothing while the compiler produces the warning below, reminding you
+This code will do nothing. Therefore, the compiler produces the warning below, reminding you
 that the future must be awaited in order for it to be executed.
 
 ```text

--- a/content/docs/getting-started/runtime.md
+++ b/content/docs/getting-started/runtime.md
@@ -21,8 +21,12 @@ current thread and process all spawned tasks in place. The
 distributes load across multiple threads. The `threaded_scheduler` is the
 default for applications and the `basic_scheduler` is the default for tests.
 
-It's important to remember that all async tasks **must** be spawned on the
-runtime or no work will be performed:
+Ultimately all asynchronous code must be polled to do any work. Polling the `Future` is
+the job of the Tokio runtime, but you must tell Tokio about the `Future` for this to
+happen.  You can directly tell Tokio about the `Future` with the [`tokio::spawn`]
+function, but you can also use `.await` inside something Tokio already knows about. In
+this example, we don't tell Tokio about the `Future` created by the asynchronous function
+[`TcpStream::connect`].
 
 ```rust
 # #![allow(unused_must_use)]
@@ -93,3 +97,5 @@ world example that takes everything we've learned so far into account.
 [`Runtime`]: https://docs.rs/tokio/0.2/tokio/runtime/struct.Runtime.html
 [`basic_scheduler`]: https://docs.rs/tokio/0.2/tokio/runtime/struct.Builder.html#method.basic_scheduler
 [`threaded_scheduler`]: https://docs.rs/tokio/0.2/tokio/runtime/struct.Builder.html#method.threaded_scheduler
+[`tokio::spawn`]: https://docs.rs/tokio/0.2/tokio/fn.spawn.html
+[`TcpStream::connect`]: https://docs.rs/tokio/0.2/tokio/net/struct.TcpStream.html#method.connect


### PR DESCRIPTION
Adds an example to `getting-started/runtime.md` regarding the fact that futures must be polled to complete them.