### PR TITLE
Update Example link to point to master.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -128,7 +128,7 @@
     <ul class="tk-footer-links">
       <li><a href="https://github.com/tokio-rs/tokio">GitHub</a></li>
       <li><a href="https://twitter.com/tokio_rs">Twitter</a></li>
-      <li><a href="https://github.com/tokio-rs/tokio/tree/v0.1.x/tokio/examples">Examples</a></li>
+      <li><a href="https://github.com/tokio-rs/tokio/tree/master/examples">Examples</a></li>
       <li><a href="/docs/overview/">About</a></li>
       <li><a href="/gsoc/">GSoC</a></li>
     </ul>


### PR DESCRIPTION
The current link is old and points to a version that predates
async/await. There is no 0.2.x branch that I can see corresponding to
the 0.1.x branch, so I'm proposing pointing to master.