### PR TITLE
simplify hello-world getting started

### DIFF
--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -6,145 +6,68 @@ menu:
     parent: getting_started
 ---
 
-To kick off our tour of Tokio, we will start with the obligatory "hello world"
-example. This program will create a TCP stream and write "hello, world!" to the stream.
-The difference between this and a Rust program that writes to a TCP stream without Tokio
-is that this program won't block program execution when the stream is created or when
-our "hello, world!" message is written to the stream.
+To kick off our tour of Tokio, we will start with a tiny client app. We'll
+connect to a socket via TCP and write "hello, world!" 
 
-Before we begin you should have a very basic understanding of how TCP streams
-work. Having an understanding of Rust’s [standard library
-implementation](https://doc.rust-lang.org/std/net/struct.TcpStream.html) is also
-helpful.
-
-Let's get started.
-
-First, generate a new crate.
+Let's get started by generating a new Rust app:
 
 ```bash
 $ cargo new hello-world
 $ cd hello-world
 ```
 
-Next, add the necessary dependencies in `Cargo.toml`:
+We'll add all Tokio features as `Cargo.toml` dependencies for a quick start:
 
 ```toml
 [dependencies]
 tokio = { version = "0.2", features = ["full"] }
 ```
 
-Tokio requires specifying the requested components using feature flags. This
-allows the user to only include what is needed to run the application, resulting
-in smaller binaries. For getting started, we depend on `full`, which includes
-all components.
-
-Next, add the following to `main.rs`:
+Then replace `main.rs` with our "hello world" code:
 
 ```rust
 # #![deny(deprecated)]
 # #![allow(unused_imports)]
 
-use tokio::io;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    // application comes here
+    let mut stream = TcpStream::connect("127.0.0.1:6142").await.unwrap();
+    println!("created stream");
+
+    let result = stream.write(b"hello world\n").await;
+    println!("wrote to stream; success={:?}", result.is_ok());
 }
 ```
 
-Here we use Tokio's own [`io`] and [`net`] modules. These modules provide the same
-abstractions over networking and I/O-operations as the corresponding modules in
-`std` with a difference: all actions are performed asynchronously.
+We `use` Tokio's [`net`] module, which provides the same
+abstraction over networking as the corresponding modules in
+`std` except asynchronously. 
 
-Next is the Tokio application entry point. This is an `async` main function
-annotated with `#[tokio::main]`. This is the function that first runs when the
-binary is executed. The `#[tokio::main]` annotation informs Tokio that this is
-where the runtime (all the infrastructure needed to power Tokio) is started.
+The `#[tokio::main]` macro provides common boilerplate for setting up the
+tokio runtime, so that we can write `main()` as an [`async function`]. This
+enables us to call asynchronous functions and write sequential code as if
+they were blocking by using the Rust `await` keyword. (See the [Async Book](https://rust-lang.github.io/async-book/index.html) for in-depth documentation of 
+Rust language features.)
 
-# Creating the TCP stream
+# Running our app
 
-The first step is to create the `TcpStream`. We use the `TcpStream` implementation
-provided by Tokio.
+Our app connects to a socket over TCP and writes to it. An easy way to listen
+on a socket is with the network utility `socat`. The following command listens
+on localhost 6142 for a TCP connection and then pipes the data to stdout:
 
-```rust,no_run
-# #![deny(deprecated)]
-#
-# use tokio::net::TcpStream;
-#[tokio::main]
-async fn main() {
-    // Connect to port 6142 on localhost
-    let stream = TcpStream::connect("127.0.0.1:6142").await.unwrap();
-
-    // Following snippets come here...
-# drop(stream);
-}
+```
+socat TCP-LISTEN:6142 stdout
 ```
 
-`TcpStream::connect` is an _asynchronous_ function. No work is done during the
-function call. Instead, `.await` is called to pause the current task until the
-connect has completed. Once the connect has completed, the task resumes. The
-`.await` call does **not** block the current thread.
-
-Next, we do work with the TCP stream.
-
-# Writing data
-
-Our goal is to write `"hello world\n"` to the stream.
-
-```rust,no_run
-# #![deny(deprecated)]
-#
-# use tokio::net::TcpStream;
-# use tokio::prelude::*;
-# #[tokio::main]
-# async fn main() {
-// Connect to port 6142 on localhost
-let mut stream = TcpStream::connect("127.0.0.1:6142").await.unwrap();
-
-stream.write_all(b"hello world\n").await.unwrap();
-
-println!("wrote to stream");
-# }
-```
-
-The [`write_all`] function is implemented for all "stream" like types. It is
-provided by the [`AsyncWriteExt`] trait. Again, the function is asynchronous, so
-no work is done unless `.await` is called. We call `.await` to perform the
-write.
-
-You can find the full example [here][full-code].
-
-# Running the code
-
-[Netcat] is a tool for quickly creating TCP sockets from the command line. The following
-command starts a listening TCP socket on the previously specified port.
-
-```bash
-$ nc -l 6142
-```
-> The command above is used with the GNU version of netcat that comes stock on many
-> unix based operating systems. The following command can be used with the
-> [NMap.org][NMap.org] version: `$ ncat -l 6142`
-
-In a different terminal we'll run our project.
-
-```bash
-$ cargo run
-```
-
-If everything goes well, you should see `hello world` printed from Netcat.
+When we run our app with `cargo run`, then `socat` outputs `hello world`.
 
 # Next steps
 
-We've only dipped our toes into Tokio and its asynchronous model. The next page in
-the guide will start digging a bit deeper into Futures and the Tokio runtime model.
+Now that we have successfully built a tiny client to get a feel for how
+Tokio works, we'll dive into more detail about how everything works.
 
-[`io`]: https://docs.rs/tokio/0.2/tokio/io/index.html
 [`net`]: https://docs.rs/tokio/0.2/tokio/net/index.html
-[`write_all`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncWriteExt.html#method.write_all
-[`AsyncWriteExt`]: https://docs.rs/tokio/0.2/tokio/io/trait.AsyncWriteExt.html
-[full-code]: https://github.com/tokio-rs/tokio/blob/master/examples/hello_world.rs
-[Netcat]: http://netcat.sourceforge.net/
-[Nmap.org]: https://nmap.org
+[`async function`]: https://doc.rust-lang.org/reference/items/functions.html#async-functions

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -25,7 +25,7 @@ tokio = { version = "0.2", features = ["full"] }
 
 Then replace `main.rs` with our "hello world" code:
 
-```rust
+```rust,no_run
 # #![deny(deprecated)]
 # #![allow(unused_imports)]
 


### PR DESCRIPTION
suggestion for how to simplify "hello world" 

- app wasn't using `io` so removed from text
- adjust text to describe as a client app (since that's what it is)
- use socat which hopefully doesn't have the same cross-platform issues as we were running into with netcat