### PR TITLE
create 'topics' in doc navigation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,9 @@ menu:
     - identifier: "getting_started"
       name: "Getting started"
       weight: 1000
+    - identifier: "topics"
+      name: "Topics"
+      weight: 2000
     - identifier: "reference"
       name: "API documentation"
       url: "https://docs.rs/tokio"
@@ -19,6 +22,7 @@ menu:
       weight: 10000
 
 
+# URL params used in /layouts/shortcodes
 params:
   tokioDocsURL: "https://docs.rs/tokio/0.1/tokio"
   tokioExecutorDocsURL: "https://docs.rs/tokio-executor/0.1/tokio_executor"
@@ -32,3 +36,4 @@ params:
   protoDocsURL: "https://tokio-rs.github.io/tokio-proto/tokio_proto"
   serviceDocsURL: "https://tokio-rs.github.io/tokio-service/tokio_service"
   bytesDocsURL: "https://docs.rs/bytes/0.4/bytes"
+  tokio01URL: "https://v0-1--tokio.netlify.com/"

--- a/content/blog/2018-03-timers.md
+++ b/content/blog/2018-03-timers.md
@@ -122,6 +122,6 @@ And with that, have a great weekend!
 [delay]: https://docs.rs/tokio/0.1/tokio/timer/struct.Delay.html
 [timeout]: https://docs.rs/tokio/0.1/tokio/timer/struct.Timeout.html
 [interval]: https://docs.rs/tokio/0.1/tokio/timer/struct.Interval.html
-[guide]: {{< ref "/docs/going-deeper/timers.md" >}}
+[guide]: {{< tokio-01 "/docs/going-deeper/timers.md" >}}
 [api]: https://docs.rs/tokio/0.1/tokio/timer/index.html
 [runtime]: {{< api-url "tokio" >}}/runtime/index.html

--- a/content/docs/futures/basic.md
+++ b/content/docs/futures/basic.md
@@ -1,6 +1,7 @@
 ---
 title: "Implementing futures"
 weight : 2020
+draft: true
 ---
 
 Implementing futures is very common when using Tokio. Let's start with a very

--- a/content/docs/futures/combinators.md
+++ b/content/docs/futures/combinators.md
@@ -1,6 +1,7 @@
 ---
 title: "Combinators"
 weight : 2040
+draft: true
 ---
 
 Often times, Future implementations follow similar patterns. To help reduce

--- a/content/docs/futures/getting_asynchronous.md
+++ b/content/docs/futures/getting_asynchronous.md
@@ -1,6 +1,7 @@
 ---
 title: "Getting asynchronous"
 weight : 2030
+draft: true
 ---
 
 Futures are all about managing asynchronicity. Implementing a future that

--- a/content/docs/futures/leaf-futures.md
+++ b/content/docs/futures/leaf-futures.md
@@ -1,6 +1,7 @@
 ---
 title: "Leaf futures"
 weight : 2070
+draft: true
 ---
 
 This page has not been worked on yet. If you'd like to contribute visit the [doc-push]

--- a/content/docs/futures/overview.md
+++ b/content/docs/futures/overview.md
@@ -1,6 +1,7 @@
 ---
 title: "Overview"
 weight : 2010
+draft: true
 ---
 
 Futures, hinted at earlier in the guide, are the building block used to manage

--- a/content/docs/futures/runtime-model.md
+++ b/content/docs/futures/runtime-model.md
@@ -1,6 +1,7 @@
 ---
 title: "Runtime model"
 weight : 2080
+draft: true
 ---
 
 This page has not been worked on yet. If you'd like to contribute visit the [doc-push]

--- a/content/docs/futures/spawning.md
+++ b/content/docs/futures/spawning.md
@@ -1,6 +1,7 @@
 ---
 title: "Spawning"
 weight : 2060
+draft: true
 ---
 
 Tokio based applications are organized in terms of Tasks. A task is a small unit

--- a/content/docs/futures/streams.md
+++ b/content/docs/futures/streams.md
@@ -1,6 +1,7 @@
 ---
 title: "Streams"
 weight : 2050
+draft: true
 ---
 
 Streams are similar to futures, but instead of yielding a single value, they

--- a/content/docs/getting-started/cargo-dependencies.md
+++ b/content/docs/getting-started/cargo-dependencies.md
@@ -1,6 +1,6 @@
 ---
 title: "Cargo dependencies"
-weight : 1020
+weight : 1015
 menu:
   docs:
     parent: getting_started

--- a/content/docs/getting-started/echo.md
+++ b/content/docs/getting-started/echo.md
@@ -1,6 +1,6 @@
 ---
 title: "Example: An Echo Server"
-weight : 1040
+weight : 1018
 menu:
   docs:
     parent: getting_started

--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -3,7 +3,7 @@ title: "async fn"
 weight : 1020
 menu:
   docs:
-    parent: getting_started
+    parent: topics
 ---
 
 Let's take a closer look at Rust's `async fn` feature. Tokio is built on top of

--- a/content/docs/getting-started/runtime.md
+++ b/content/docs/getting-started/runtime.md
@@ -3,7 +3,7 @@ title: "Runtime"
 weight : 1030
 menu:
   docs:
-    parent: getting_started
+    parent: topics
 ---
 
 In the previous section we explored `async fn` Futures which allow us to represent

--- a/content/docs/going-deeper/building-runtime.md
+++ b/content/docs/going-deeper/building-runtime.md
@@ -1,6 +1,7 @@
 ---
 title: "Building a runtime"
 weight: 7100
+draft: true
 ---
 
 The runtime ‒ all the pieces needed to run an event driven application ‒ is

--- a/content/docs/going-deeper/chat.md
+++ b/content/docs/going-deeper/chat.md
@@ -1,6 +1,7 @@
 ---
 title: "Example: A Chat Server"
 weight : 7050
+draft: true
 ---
 
 We're going to use what has been covered so far to build a chat server. This is

--- a/content/docs/going-deeper/frames.md
+++ b/content/docs/going-deeper/frames.md
@@ -1,6 +1,7 @@
 ---
 title: "Working with framed streams"
 weight: 7090
+draft: true
 ---
 
 Tokio has helpers to transform a stream of bytes into a stream of frames. Examples

--- a/content/docs/going-deeper/futures-mechanics.md
+++ b/content/docs/going-deeper/futures-mechanics.md
@@ -1,6 +1,7 @@
 ---
 title: "Essential combinators"
 weight: 7070
+draft: true
 ---
 
 We saw a few of the most important combinators in the

--- a/content/docs/going-deeper/futures.md
+++ b/content/docs/going-deeper/futures.md
@@ -1,6 +1,7 @@
 ---
 title: "Futures: In Depth"
 weight : 7010
+draft: true
 ---
 
 Futures, hinted at earlier in the guide, are the building block used to manage

--- a/content/docs/going-deeper/io.md
+++ b/content/docs/going-deeper/io.md
@@ -1,6 +1,7 @@
 ---
 title: "I/O with Tokio"
 weight : 7040
+draft: true
 ---
 
 The [`tokio`] crate comes with TCP and UDP networking types. Unlike the types in

--- a/content/docs/going-deeper/returning.md
+++ b/content/docs/going-deeper/returning.md
@@ -1,6 +1,7 @@
 ---
 title: "Returning futures"
 weight: 7080
+draft: true
 ---
 
 [`Future`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html

--- a/content/docs/going-deeper/runtime-model.md
+++ b/content/docs/going-deeper/runtime-model.md
@@ -1,6 +1,7 @@
 ---
 title: "Runtime Model"
 weight : 7030
+draft: true
 ---
 
 Now we will go over the Tokio / futures runtime model. Tokio is built on top of

--- a/content/docs/going-deeper/tasks.md
+++ b/content/docs/going-deeper/tasks.md
@@ -1,6 +1,7 @@
 ---
 title: "Tasks"
 weight : 7020
+draft: true
 ---
 
 Tasks are the application's "unit of logic". They are similar to [Go's

--- a/content/docs/going-deeper/timers.md
+++ b/content/docs/going-deeper/timers.md
@@ -1,6 +1,7 @@
 ---
 title: "Timers"
 weight: 7060
+draft: true
 ---
 
 When writing a network based application, it is common to need to perform

--- a/content/docs/internals/intro.md
+++ b/content/docs/internals/intro.md
@@ -1,6 +1,7 @@
 ---
 title: "Introduction"
 weight: 8001
+draft: true
 ---
 
 The internals section provides an in-depth guide of Tokio's internals. It

--- a/content/docs/internals/net.md
+++ b/content/docs/internals/net.md
@@ -1,6 +1,7 @@
 ---
 title: "Non-blocking I/O"
 weight: 8020
+draft: true
 ---
 
 This section describes the network resources and drivers provided by Tokio. This

--- a/content/docs/internals/runtime-model.md
+++ b/content/docs/internals/runtime-model.md
@@ -1,6 +1,7 @@
 ---
 title: "Runtime model"
 weight: 8010
+draft: true
 ---
 
 Applications written using Tokio are organized across a large number of small,

--- a/content/docs/io/async_read_write.md
+++ b/content/docs/io/async_read_write.md
@@ -1,6 +1,7 @@
 ---
 title: "Using AsyncRead and AsyncWrite directly"
 weight : 3030
+draft: true
 ---
 
 So far, we have primarily talked about `AsyncRead` and `AsyncWrite` in

--- a/content/docs/io/datagrams.md
+++ b/content/docs/io/datagrams.md
@@ -1,6 +1,7 @@
 ---
 title: "Datagram APIs"
 weight : 3060
+draft: true
 ---
 
 This page has not been worked on yet. If you'd like to contribute visit the [doc-push]

--- a/content/docs/io/filesystem.md
+++ b/content/docs/io/filesystem.md
@@ -1,6 +1,7 @@
 ---
 title: "Filesystem APIs"
 weight : 3050
+draft: true
 ---
 
 This page has not been worked on yet. If you'd like to contribute visit the [doc-push]

--- a/content/docs/io/impl_async_read_write.md
+++ b/content/docs/io/impl_async_read_write.md
@@ -1,6 +1,7 @@
 ---
 title: "Implementing Async Read/Write"
 weight : 3040
+draft: true
 ---
 
 This page has not been worked on yet. If you'd like to contribute visit the [doc-push]

--- a/content/docs/io/overview.md
+++ b/content/docs/io/overview.md
@@ -1,6 +1,7 @@
 ---
 title: "I/O Overview"
 weight : 3010
+draft: true
 ---
 
 The Rust standard library provides support for networking and I/O, such

--- a/content/docs/io/reading_writing_data.md
+++ b/content/docs/io/reading_writing_data.md
@@ -1,6 +1,7 @@
 ---
 title: "Reading and Writing Data"
 weight : 3020
+draft: true
 ---
 
 

--- a/content/docs/network-utilities/overview.md
+++ b/content/docs/network-utilities/overview.md
@@ -1,0 +1,8 @@
+---
+title: "Network Utilities"
+weight: 9000
+---
+
+This section is not about Tokio. For network programming, testing and debugging,
+there are a set of utilities that we've found helpful and are referenced in the
+guides.

--- a/content/docs/network-utilities/socat.md
+++ b/content/docs/network-utilities/socat.md
@@ -1,5 +1,6 @@
 ---
 title: "socat"
+weight: 9200
 menu:
   docs:
     parent: network_utils

--- a/content/docs/network-utilities/telnet.md
+++ b/content/docs/network-utilities/telnet.md
@@ -1,5 +1,6 @@
 ---
 title: "telnet"
+weight: 9300
 menu:
   docs:
     parent: network_utils

--- a/layouts/shortcodes/tokio-01.html
+++ b/layouts/shortcodes/tokio-01.html
@@ -1,0 +1,1 @@
+{{- .Site.Params.tokio01URL -}}


### PR DESCRIPTION
Suggested organization of docs left-nav:

Guides at the top, where right now we just have "Getting started" but we plan to have more tutorial content.

This PR adds "Topics" section for pages about specific tokio features/concepts that benefit from additional narrative (might have supporting examples, but not step-by-step tutorial)

To fix text at the end of the echo server guide, currently refers to "next section" as futures, we need to make it so content hidden from the nav is really hidden. To do that I used the hugo `draft` feature (where `draft: true` front matter causes pages to not be rendered)

Instead of waiting for merge of other PRs that were submitted before this one with changes to `getting-started/futures.md` and `getting-started/runtime.md`, I just didn't move them for now.
