### PR TITLE
left navigation in documentation: indent subtopics for readability

### DIFF
--- a/static/css/tokio.css
+++ b/static/css/tokio.css
@@ -223,6 +223,7 @@ img {
 }
 
 .tk-sidenav {
+  padding-left: 15px;
   display: none;
 }
 


### PR DESCRIPTION
I was having trouble reading what are categories vs pages within the categories
I think indenting the page titles in the left nav helps a bit.  Added before/after shots below (though ignore the content change which is just that the branch is from a little while ago -- these changes are just the visual layout indent, no content changes).

## Before
![image](https://user-images.githubusercontent.com/41906/73100527-90039780-3ea2-11ea-8764-07812da79bbf.png)

## After
![image](https://user-images.githubusercontent.com/41906/73100479-78c4aa00-3ea2-11ea-897e-bf8992e0ff0a.png)
