### PR TITLE
socat fails with space after comma

### DIFF
--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -55,7 +55,7 @@ out everything that is received on port 6142 (a somewhat arbitrary number
 we have chosen for this example):
 
 ```bash
-socat TCP-LISTEN:6142, fork stdout
+socat TCP-LISTEN:6142,fork stdout
 ```
 
 An easy way to simulate a client (for a text-based protocol) is to use


### PR DESCRIPTION

```
$ socat TCP-LISTEN:6142, fork stdout
2020/01/14 09:24:38 socat[52031] E exactly 2 addresses required (there are 3); use option "-h" for help
```

needs to be without a space after the comma -- rrgh!
```
$ socat TCP-LISTEN:6142,fork stdout
```
