### PR TITLE
netlify redirect for /docs => docHome

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,3 +16,10 @@
 
   [context.branch-deploy]
   command = "hugo -b $DEPLOY_PRIME_URL"
+
+  [[redirects]]
+  from = "/docs"
+  to = "/docs/getting-started/hello-world/"
+  status = 301
+  force = false
+  query = {path = ":path"}


### PR DESCRIPTION
I didn't find a good answer to this in hugo docs, so trying out netlify config to redirect

to fix https://github.com/tokio-rs/website/issues/409