### PR TITLE
docs: add unwrap to prevent passing Result to write

### DIFF
--- a/content/docs/getting-started/cargo-dependencies.md
+++ b/content/docs/getting-started/cargo-dependencies.md
@@ -94,7 +94,7 @@ use tokio::net::TcpStream;
 #[tokio::main]
 async fn main() {
   let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 6142);
-  let mut stream = TcpStream::connect(addr).await;
+  let mut stream = TcpStream::connect(addr).await.unwrap();
 }
 ```
 


### PR DESCRIPTION
This prevents an issue for beginners going through the getting started docs where they do not know that they need to call .unwrap() so that a result is not passed into write(). Not doing this will give the following error:

```
error[E0599]: no method named `write` found for type `std::result::Result<tokio::net::tcp::stream::TcpStream, std::io::Error>` in the current scope

let result = stream.write(b"hello world\n").await;
                             ^^^^^ method not found in `std::result::Result<tokio::net::tcp::stream::TcpStream, std::io::Error>`

note: the method `write` exists but the following trait bounds were not satisfied:
          `std::result::Result<tokio::net::tcp::stream::TcpStream, std::io::Error> : tokio::io::util::async_write_ext::AsyncWriteExt`
```