### PR TITLE
remove stale comment

### DIFF
--- a/content/docs/getting-started/echo.md
+++ b/content/docs/getting-started/echo.md
@@ -66,8 +66,7 @@ async fn main() {
     let mut listener = TcpListener::bind(addr).await.unwrap();
 
     // Here we convert the `TcpListener` to a stream of incoming connections
-    // with the `incoming` method. We then define how to process each element in
-    // the stream with the `for_each` combinator method
+    // with the `incoming` method.
     let server = async move {
         let mut incoming = listener.incoming();
         while let Some(socket_res) = incoming.next().await {


### PR DESCRIPTION
fixes https://github.com/tokio-rs/website/issues/369

I just removed the part that refers to `for_each` since now the code uses `next` 
better to describe in the text or API docs if anyone wants to go into detail about that