### PR TITLE
Fix typo in futures.md

### DIFF
--- a/content/docs/getting-started/futures.md
+++ b/content/docs/getting-started/futures.md
@@ -109,7 +109,7 @@ When the process receives the I/O notification from the operating system, it
 finds the function associated with it and calls it immediately. This is a
 **push** based model because the value is **pushed** into the callback.
 
-The rust asynchronous model is **pull** based. Instead of a `Future`
+The rust asynchronous model is **poll** based. Instead of a `Future`
 being responsible for pushing the data into a callback, it relies on **something
 else** asking if it is complete or not. In the case of Tokio, that **something
 else** is the Tokio runtime.


### PR DESCRIPTION
Replace "pull" with "poll" when describing the Rust asynchronous model.