### PR TITLE
Adds SVG favicon

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -13,6 +13,8 @@ const Layout: FC<Props> = ({ blog, children }) => (
     <Head>
       <title>Tokio</title>
       <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <link rel="alternate icon" type="image/png" href="favicon-32x32.png"/>
+      <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
       <link
         href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;600;700&display=swap"
         rel="stylesheet"

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 29" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+  <defs>
+    <style type="text/css"><![CDATA[
+      #Page-1 {
+        fill: #000000;
+      }
+      @media (prefers-color-scheme: dark) {
+        #Page-1 {
+          fill: #FFFFFF;
+        }
+      }
+    ]]></style>
+  </defs>
+<g id="Page-1"><g id="_01" serif:id="01"><g id="Group-Copy-2"><g id="Group"><g id="Mark-Copy"><path id="Line-Copy-3" d="M11.688,16.237l-4.159,2.4l0.534,0.925l4.158,-2.401l-0.533,-0.924Z"/><path id="Line" d="M19.801,17.161l4.158,2.401l0.534,-0.925l-4.159,-2.4l-0.533,0.924Z"/><path id="Oval-Copy-2" d="M21.346,14.431c0,-2.947 -2.388,-5.335 -5.335,-5.335c-2.947,0 -5.335,2.388 -5.335,5.335c0,2.947 2.388,5.335 5.335,5.335c2.947,0 5.335,-2.388 5.335,-5.335Zm-9.541,0c0,-2.323 1.883,-4.206 4.206,-4.206c2.323,0 4.206,1.883 4.206,4.206c0,2.323 -1.883,4.206 -4.206,4.206c-2.323,0 -4.206,-1.883 -4.206,-4.206Z"/><circle id="Oval-Copy-6" cx="6.407" cy="20.033" r="0.8"/><circle id="Oval-Copy-12" cx="16.011" cy="25.635" r="0.8"/><circle id="Oval-Copy-13" cx="16.011" cy="3.227" r="0.8"/><circle id="Oval-Copy-14" cx="25.615" cy="8.829" r="0.8"/><circle id="Oval-Copy-16" cx="6.407" cy="8.829" r="0.8"/><circle id="Oval-Copy-15" cx="25.615" cy="20.033" r="0.8"/><circle id="Oval-Copy-61" serif:id="Oval-Copy-6" cx="16.011" cy="14.431" r="0.8"/><path id="Line1" serif:id="Line" d="M11.209,13.898l-11.204,0l0,1.067l11.204,0l0,-1.067Z"/><path id="Line2" serif:id="Line" d="M32.017,13.898l-11.204,0l0,1.067l11.204,0l0,-1.067Z"/><path id="Line-Copy-4" d="M24.536,27.562l-5.371,-9.22l-0.922,0.537l5.371,9.22l0.269,0.461l0.922,-0.537l-0.269,-0.461Z"/><path id="Line-Copy-41" serif:id="Line-Copy-4" d="M14.068,9.817l-5.64,-9.681l-0.922,0.537l5.64,9.681l0.922,-0.537Z"/><path id="Line-Copy-7" d="M18.832,10.354l5.64,-9.681l-0.922,-0.537l-5.64,9.681l0.922,0.537Z"/><path id="Line-Copy-71" serif:id="Line-Copy-7" d="M8.461,28.151l5.371,-9.22l-0.922,-0.537l-5.371,9.22l-0.269,0.461l0.922,0.537l0.269,-0.461Z"/><path id="Line3" serif:id="Line" d="M15.477,18.966l0,4.802l1.067,0l0,-4.802l-1.067,0Z"/><path id="Line4" serif:id="Line" d="M15.477,5.094l0,4.802l1.067,0l0,-4.802l-1.067,0Z"/><path id="Line-Copy-2" d="M7.529,10.225l4.159,2.401l0.533,-0.924l-4.158,-2.401l-0.534,0.924Z"/><path id="Line-Copy" d="M23.959,9.301l-4.158,2.401l0.533,0.924l4.159,-2.401l-0.534,-0.924Z"/></g></g></g></g></g></svg>


### PR DESCRIPTION
This adds an SVG favicon using the existing Tokio logo here: https://github.com/tokio-rs/website/blob/master/public/img/icons/tokio.svg. It's resized and supports dark mode (using CSS media query). Website falls back on the PNG favicon if the browser doesn't support SVG.

Tested against Chrome, Firefox, and Safari on macOS.

<img width="70" alt="Screenshot 2020-07-21 at 10 44 00" src="https://user-images.githubusercontent.com/47347/88088689-ab90e780-cb3f-11ea-9b56-1a1bee9e188f.png"><img width="74" alt="Screenshot 2020-07-21 at 10 43 44" src="https://user-images.githubusercontent.com/47347/88088692-ac297e00-cb3f-11ea-8ffc-7c515211596f.png">

Currently, the PNG favicon does not support dark mode. Ideally, this favicon should be modified to work on either light or dark mode. Something to consider in the future.
