### PR TITLE
Fix typos in tutorial

### DIFF
--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -35,8 +35,6 @@ To depend on `bytes`, add the following to your `Cargo.toml` in the
 bytes = "0.5"
 ```
 
-Then run `cargo install`.
-
 [`bytes`]: https://docs.rs/bytes/0.5/bytes/struct.Bytes.html
 
 # Initialize the `HashMap`

--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -368,7 +368,7 @@ Now, start the server:
 $ cargo run
 ```
 
-and in a separate terminal window, run the `hello-tokio` example:
+and in a separate terminal window, run the `hello-redis` example:
 
 ```bash
 $ cargo run --example hello-redis


### PR DESCRIPTION
It doesn't make sense to run `cargo install` after adding the `bytes` dependency.