### PR TITLE
Fix typo

### DIFF
--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -94,9 +94,9 @@ within async code. An async mutex is a mutex that is locked across calls to
 `.await`.
 
 A synchronous mutex will block the current thread when waiting to acquire the
-the lock. This, in turn, will block other tasks from processing. However,
-switching to `tokio::sync::Mutex` usually does not help as the asynchronous
-mutex uses a synchronous mutex internally.
+lock. This, in turn, will block other tasks from processing. However, switching
+to `tokio::sync::Mutex` usually does not help as the asynchronous mutex uses a
+synchronous mutex internally.
 
 As a rule of thumb, using a synchronous mutex from within asynchronous code is
 fine as long as contention remains low and the lock is not held across calls to


### PR DESCRIPTION
This changes `the\nthe` -> `the` and word wraps the paragraph.