### PR TITLE
Fix: Missing decrement in Interval stream example

### DIFF
--- a/content/tokio/tutorial/streams.md
+++ b/content/tokio/tutorial/streams.md
@@ -357,7 +357,7 @@ impl Stream for Interval {
         match Pin::new(&mut self.delay).poll(cx) {
             Poll::Ready(_) => {
                 let when = self.delay.when + Duration::from_millis(10);
-                self.delay = Delay {when };
+                self.delay = Delay { when };
                 self.rem -= 1;
                 Poll::Ready(Some(()))
             }

--- a/content/tokio/tutorial/streams.md
+++ b/content/tokio/tutorial/streams.md
@@ -358,6 +358,7 @@ impl Stream for Interval {
             Poll::Ready(_) => {
                 let when = self.delay.when + Duration::from_millis(10);
                 self.delay = Delay {when };
+                self.rem -= 1;
                 Poll::Ready(Some(()))
             }
             Poll::Pending => Poll::Pending,

--- a/content/tokio/tutorial/streams.md
+++ b/content/tokio/tutorial/streams.md
@@ -323,7 +323,7 @@ and other streams. As an example, let's build off of the `Delay` future we
 implemented in [Async in depth][async]. We will convert it to a stream that
 yields `()` three times at 10 ms intervals
 
-```
+```rust
 use tokio::stream::Stream;
 # use std::future::Future;
 use std::pin::Pin;


### PR DESCRIPTION
Also add rust syntax highlighting to markdown fence of example.

Fixes #467.