### PR TITLE
Fixes favicon path

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -13,8 +13,8 @@ const Layout: FC<Props> = ({ blog, children }) => (
     <Head>
       <title>Tokio</title>
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <link rel="alternate icon" type="image/png" href="favicon-32x32.png" />
-      <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+      <link rel="alternate icon" type="image/png" href="/favicon-32x32.png" />
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       <link rel="alternate" type="application/rss+xml" href="/_next/static/feed.xml" />
 
       <link


### PR DESCRIPTION
#430 used a relative path to the favicon. This always fetches the favicon from the root.