### PR TITLE
Minor typo in channels.md

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -62,7 +62,7 @@ Tokio provides a [number of channels][channels], each serving a different purpos
 
 - [mpsc]: multi-producer, single-consumer channel. Many values can be sent.
 - [oneshot]: single-producer, single consumer channel. A single value can be sent.
-- [broadcast]: multi-producer, multi-consumer. Many values can be send. Each
+- [broadcast]: multi-producer, multi-consumer. Many values can be sent. Each
   receiver sees every value.
 - [watch]: single-producer, multi-consumer. Many values can be sent, but no
   history is kept. Receivers only see the most recent value.


### PR DESCRIPTION
Fix a minor typo:

    Many values can be send. => Many values can be sent.