### PR TITLE
A mistake in shared-state.md?

### DIFF
--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -190,7 +190,7 @@ introduce `N` distinct instances.
 ```rust
 # use std::collections::HashMap;
 # use std::sync::{Arc, Mutex};
-type ShardedDb = Arc<Vec<Mutex<HashMap<String, Vec<u8>>>>>;
+type ShardedDb = Arc<Vec<Arc<Mutex<HashMap<String, Vec<u8>>>>>>;
 ```
 
 Then, finding the cell for any given key becomes a two step process. First, the


### PR DESCRIPTION
It's common to create `ShardedDb` like
```rust
let sharded_db = Arc::new(vec![Mutex::new(HashMap::new()); 16]);
```
but `vec!` requires elements impl `Clone`, which is not `Mutex` do.

Change `ShardedDb` type to `Arc<Vec<Arc<Mutex<HashMap<String, Vec<u8>>>>>>` (an extra `Arc` between `Vec` and `Mutex`) is able to solve the problem:

Create `ShardedDb` like
```rust
let sharded_db = Arc::new(vec![Arc::new(Mutex::new(HashMap::new())); 16]);
```