### PR TITLE
[Docs code] fix "cannot borrow tx and tx2 as mutable"

### DIFF
--- a/tutorial-code/channels/src/main.rs
+++ b/tutorial-code/channels/src/main.rs
@@ -22,9 +22,9 @@ type Responder<T> = oneshot::Sender<mini_redis::Result<T>>;
 
 #[tokio::main]
 async fn main() {
-    let (tx, mut rx) = mpsc::channel(32);
+    let (mut tx, mut rx) = mpsc::channel(32);
     // Clone a `tx` handle for the second f
-    let tx2 = tx.clone();
+    let mut tx2 = tx.clone();
 
     let manager = tokio::spawn(async move {
         // Open a connection to the mini-redis address.


### PR DESCRIPTION
[Channel tutorial example code](https://github.com/tokio-rs/website/blob/master/tutorial-code/channels/src/main.rs) gives the following error:
```
cannot borrow `tx` as mutable, as it is not declared as mutable
cannot borrow as mutable

cannot borrow `tx2` as mutable, as it is not declared as mutable
cannot borrow as mutable
```