### PR TITLE
Clarify function name in "framing" guide

### DIFF
--- a/content/tokio/tutorial/framing.md
+++ b/content/tokio/tutorial/framing.md
@@ -427,7 +427,7 @@ use mini_redis::Frame;
 #   buffer: bytes::BytesMut,
 # }
 # impl Connection {
-async fn write_value(&mut self, frame: &Frame)
+async fn write_frame(&mut self, frame: &Frame)
     -> io::Result<()>
 {
     match frame {


### PR DESCRIPTION
The code snippet provided in the guide appears to be a hybrid of the `write_frame` and `write_value` functions in the "final" code in https://github.com/tokio-rs/mini-redis/blob/tutorial/src/connection.rs#L159-L184.

I was initially confused why the sentence preceding the snippet mentioned `write_frame` but the code in the snippet is for a function called `write_value`. The provided snippet is *more* similar to the `write_value` function in the final code, but since it's purpose in the guide is to actually write a frame, `write_frame` seems like a clearer name for this specific snippet.