### PR TITLE
Remove mut in tutorial variables that cause warnings

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -118,7 +118,7 @@ use tokio::sync::mpsc;
 #[tokio::main]
 async fn main() {
     // Create a new channel with a capacity of at most 32.
-    let (mut tx, mut rx) = mpsc::channel(32);
+    let (tx, mut rx) = mpsc::channel(32);
 # tx.send(()).await.unwrap();
 
     // ... Rest comes here
@@ -142,8 +142,8 @@ use tokio::sync::mpsc;
 
 #[tokio::main]
 async fn main() {
-    let (mut tx, mut rx) = mpsc::channel(32);
-    let mut tx2 = tx.clone();
+    let (tx, mut rx) = mpsc::channel(32);
+    let tx2 = tx.clone();
 
     tokio::spawn(async move {
         tx.send("sending from first handle").await;
@@ -220,7 +220,7 @@ them directly on the Redis connection.
 # let (mut tx, _) = tokio::sync::mpsc::channel(10);
 // The `Sender` handles are moved into the tasks. As there are two
 // tasks, we need a second `Sender`.
-let mut tx2 = tx.clone();
+let tx2 = tx.clone();
 
 // Spawn two tasks, one gets a key, the other sets a key
 let t1 = tokio::spawn(async move {


### PR DESCRIPTION
First off, I want to say thank you all for writing the excellent tutorials for Tokio. I didn't realize they existed until I was reading about the 1.0 release. I have struggled a bit with Rust in more complex projects, and adding Tokio's asynchronous fanciness on top of that has always seemed a bit daunting. These tutorials do an excellent job demystifying the project and getting me excited to use it.

While walking through the tutorial, I saw warnings while following along with the code snippets. The sample snippets suggested making a couple of variables mutable that the compiler said didn't need to be. They are not mutable in [the final checked-in code sample](https://github.com/tokio-rs/website/blob/master/tutorial-code/channels/src/main.rs#L25-L27), either.

I was worried that they might be mutable to appease the doc tests, but all the tests mentioned in the README still seem to pass. 