### PR TITLE
Open up social links in new tab

### DIFF
--- a/components/social-links.tsx
+++ b/components/social-links.tsx
@@ -23,6 +23,7 @@ const SocialLinks: FC = () => (
   <>
     {DATA.map((link) => (
       <a
+        target="_blank"
         className="navbar-item navbar-icon tk-social"
         href={link.url}
         key={link.name}


### PR DESCRIPTION
This commit makes the social links open up on a new tag instead of replacing the website tab