### PR TITLE
Import futures::task::self in async chapter

### DIFF
--- a/content/tokio/tutorial/async.md
+++ b/content/tokio/tutorial/async.md
@@ -504,7 +504,7 @@ futures = "0.3"
 Then implement [`futures::task::ArcWake`][`ArcWake`].
 
 ```rust
-use futures::task::ArcWake;
+use futures::task::{self, ArcWake};
 use std::sync::Arc;
 # struct Task {}
 # impl Task {


### PR DESCRIPTION
Hello, I noticed that the mini tokio tutorial code didn't work unless I added a `use futures::task::self;` statement. It looks like `task::self` is included in the code snippet, but it's commented out and doesn't render on the site itself. 

This PR adds the necessary import statement in one possible place, namely the `impl ArcWake for Task` block. The statement could alternatively be added in the `impl MiniTokio` block a bit further down. 