### PR TITLE
Fix link URLs and typo in tutorial

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -77,11 +77,11 @@ In this section, we will use [mpsc] and [oneshot]. The other types of message
 passing channels are explored in later sections. The full code from this section
 is found [here][full].
 
-[channels]: https://docs.rs/tokio/0.3/tokio/sync/index.html
-[mpsc]: https://docs.rs/tokio/0.3/tokio/sync/mpsc/index.html
-[oneshot]: https://docs.rs/tokio/0.3/tokio/sync/oneshot/index.html
-[broadcast]: https://docs.rs/tokio/0.3/tokio/sync/broadcast/index.html
-[watch]: https://docs.rs/tokio/0.3/tokio/sync/watch/index.html
+[channels]: https://docs.rs/tokio/1/tokio/sync/index.html
+[mpsc]: https://docs.rs/tokio/1/tokio/sync/mpsc/index.html
+[oneshot]: https://docs.rs/tokio/1/tokio/sync/oneshot/index.html
+[broadcast]: https://docs.rs/tokio/1/tokio/sync/broadcast/index.html
+[watch]: https://docs.rs/tokio/1/tokio/sync/watch/index.html
 [`async-channel`]: https://docs.rs/async-channel/
 [`std::sync::mpsc`]: https://doc.rust-lang.org/stable/std/sync/mpsc/index.html
 [`crossbeam::channel`]: https://docs.rs/crossbeam/latest/crossbeam/channel/index.html

--- a/content/tokio/tutorial/hello-tokio.md
+++ b/content/tokio/tutorial/hello-tokio.md
@@ -91,7 +91,7 @@ the operation is performed asynchronously, the code we write **looks**
 synchronous. The only indication that the operation is asynchronous is the
 `.await` operator.
 
-[`client::connect`]: https://docs.rs/mini-redis/0.1/mini_redis/client/fn.connect.html
+[`client::connect`]: https://docs.rs/mini-redis/0.4/mini_redis/client/fn.connect.html
 
 ## What is asynchronous programming?
 

--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -324,7 +324,7 @@ async fn increment_and_do_stuff(can_incr: &CanIncrement) {
 }
 # async fn do_something_async() {}
 ```
-This pattern guarantees that you wont run into the `Send` error, because the
+This pattern guarantees that you won't run into the `Send` error, because the
 mutex guard does not appear anywhere in an async function.
 
 ## Spawn a task to manage the state and use message passing to operate on it

--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -8,8 +8,8 @@ First, move the client `SET`/`GET` code from the previous section to an example
 file. This way, we can run it against our server.
 
 ```bash
-mkdir -p examples
-mv src/main.rs examples/hello-redis.rs
+$ mkdir -p examples
+$ mv src/main.rs examples/hello-redis.rs
 ```
 
 Then create a new, empty `src/main.rs` and continue.


### PR DESCRIPTION
While reading the tutorial, I found several points to be fixed. So, this PR consists of:

- updates link URLs to crates' documentation
- fixes typo
- adds dollar signs before shell commands for consistency with the other examples