### PR TITLE
Fix link URL and typo in tutorial

### DIFF
--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -274,9 +274,7 @@ tokio::spawn(async move {
 # }
 ```
 
-You can find the entire code [here][full].
-
-[full]: https://github.com/tokio-rs/website/blob/master/tutorial-code/io/src/echo-server-copy.rs
+You can find the entire code [here][full_copy].
 
 ## Manual copying
 
@@ -409,9 +407,11 @@ Forgetting to break from the read loop usually results in a 100% CPU infinite
 loop situation. As the socket is closed, `socket.read()` returns immediately.
 The loop then repeats forever.
 
-Full code can be found [here][full].
+Full code can be found [here][full_manual].
 
-[full]: https://github.com/tokio-rs/website/blob/master/tutorial-code/io/src/echo-server.rs
+[full_manual]: https://github.com/tokio-rs/website/blob/master/tutorial-code/io/src/echo-server.rs
+[full_copy]: https://github.com/tokio-rs/website/blob/master/tutorial-code/io/src/echo-server-copy.rs
+
 [send]: /tokio/tutorial/spawning#send-bound
 
 [`AsyncRead`]: https://docs.rs/tokio/1/tokio/io/trait.AsyncRead.html

--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -280,7 +280,7 @@ You can find the entire code [here][full].
 
 ## Manual copying
 
-Now lets look at how we would write the echo server by copying the data
+Now let's look at how we would write the echo server by copying the data
 manually. To do this, we use [`AsyncReadExt::read`][read] and
 [`AsyncWriteExt::write_all`][write_all].
 


### PR DESCRIPTION
Currently the link to the `copy` version of echo server seems wrong. If people click this link, they are brought to the `manual` example. So in this PR I've fixed it.
In addition, also fixed a typo :)