### PR TITLE
Specify that two terminal windows are required

### DIFF
--- a/content/tokio/tutorial/index.md
+++ b/content/tokio/tutorial/index.md
@@ -74,7 +74,7 @@ Make sure that it was successfully installed by starting the server:
 $ mini-redis-server
 ```
 
-Then try to get the key `foo` using `mini-redis-cli`
+Then, in a separate terminal window, try to get the key `foo` using `mini-redis-cli`
 
 ```bash
 $ mini-redis-cli get foo


### PR DESCRIPTION
I'm going through tokio's tutorial and thought it'd be better to specify that the reader must open a new terminal window to try the `$ mini-redis-cli get foo` command. Let me know what you guys think :)