### PR TITLE
tutorial: Fix crate name for mini-redis

### DIFF
--- a/content/tokio/tutorial/hello-tokio.md
+++ b/content/tokio/tutorial/hello-tokio.md
@@ -61,7 +61,7 @@ $ mini-redis-server
 If you have not already installed mini-redis, you can do so with
 
 ```bash
-$ cargo install mini-redis-server
+$ cargo install mini-redis
 ```
 
 Now, run the `my-redis` application:


### PR DESCRIPTION
The `cargo install` command did not refer to the actual crate name.