### PR TITLE
Upgrade crossbeam to 0.8.0

### DIFF
--- a/content/tokio/tutorial/async.md
+++ b/content/tokio/tutorial/async.md
@@ -437,7 +437,7 @@ library channel is not `Sync`.
 Add the following dependency to your `Cargo.toml` to pull in channels.
 
 ```toml
-crossbeam = "0.7"
+crossbeam = "0.8"
 ```
 
 Then, update the `MiniTokio` struct.

--- a/doc-test/Cargo.toml
+++ b/doc-test/Cargo.toml
@@ -14,7 +14,7 @@ tokio-stream = "0.1"
 bytes = "1"
 futures = "0.3"
 doc-comment = "0.3.3"
-crossbeam = "0.7"
+crossbeam = "0.8"
 
 [build-dependencies]
 glob = "0.3"

--- a/tutorial-code/mini-tokio/Cargo.toml
+++ b/tutorial-code/mini-tokio/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 
 [dependencies]
 futures = "0.3"
-crossbeam = "0.7"
+crossbeam = "0.8"


### PR DESCRIPTION
I noticed the version of crossbeam to be outdated. This just upgrades crossbeam to 0.8.0. 