### PR TITLE
Revert ".into -> Bytes::from"

### DIFF
--- a/content/tokio/tutorial/hello-tokio.md
+++ b/content/tokio/tutorial/hello-tokio.md
@@ -40,7 +40,7 @@ pub async fn main() -> Result<()> {
     let mut client = client::connect("127.0.0.1:6379").await?;
 
     // Set the key "hello" with value "world"
-    client.set("hello", bytes::Bytes::from("world")).await?;
+    client.set("hello", "world".into()).await?;
 
     // Get key "hello"
     let result = client.get("hello").await?;
@@ -139,8 +139,8 @@ pub async fn connect<T: ToSocketAddrs>(addr: T) -> Result<Client> {
 
 The `async fn` definition looks like a regular synchronous function, but
 operates asynchronously. Rust transforms the `async fn` at **compile** time into
-a routine that operates asynchronously. Any calls to `.await` within the
-`async fn` yield control back to the thread. The thread may do other work while the
+a routine that operates asynchronously. Any calls to `.await` within the `async
+fn` yield control back to the thread. The thread may do other work while the
 operation processes in the background.
 
 [[warning]]

--- a/tutorial-code/hello-tokio/Cargo.toml
+++ b/tutorial-code/hello-tokio/Cargo.toml
@@ -8,6 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1.0.1"
 tokio = { version = "1", features = ["full"] }
 mini-redis = "0.4"

--- a/tutorial-code/hello-tokio/src/main.rs
+++ b/tutorial-code/hello-tokio/src/main.rs
@@ -6,7 +6,7 @@ async fn main() -> mini_redis::Result<()> {
     let mut client = client::connect("127.0.0.1:6379").await?;
 
     // Set the key "hello" with value "world"
-    client.set("hello", bytes::Bytes::from("world")).await?;
+    client.set("hello", "world".into()).await?;
 
     // Get key "hello"
     let result = client.get("hello").await?;


### PR DESCRIPTION
Reverts #550.
Closes #553.

It is too early to introduce the `bytes` crate on the Hello Tokio page. Using `.into()` allows us to avoid doing that on this page.