### PR TITLE
Fix select chapter in tutorial

### DIFF
--- a/content/tokio/tutorial/select.md
+++ b/content/tokio/tutorial/select.md
@@ -619,11 +619,9 @@ error[E0599]: no method named `poll` found for struct
            `&mut impl std::future::Future: std::future::Future`
 ```
 
-This error isn't very clear and we haven't talked much about `Future` yet
-either. For now, think of `Future` as the trait that must be implemented by a
-value in order to call `.await` on it. If you hit an error about `Future` not
-being implemented when attempting to call `.await` on a **reference**, then the
-future probably needs to be pinned.
+Although we covered `Future` in [the previous chapter][async], this error still isn't
+very clear. If you hit such an error about `Future` not being implemented when attempting
+to call `.await` on a **reference**, then the future probably needs to be pinned.
 
 Read more about [`Pin`][pin] on the [standard library][pin].
 

--- a/content/tokio/tutorial/select.md
+++ b/content/tokio/tutorial/select.md
@@ -704,7 +704,7 @@ returned. The first loop iteration, `operation` completes immediately with
 `None`.
 
 This example uses some new syntax. The first branch includes `, if !done`. This
-is a branch precondition. Before explaining how it works, lets look at what
+is a branch precondition. Before explaining how it works, let's look at what
 happens if the precondition is omitted. Leaving out `, if !done` and running the
 example results in the following output:
 


### PR DESCRIPTION
Reading the "select" chapter in the tutorial, I was puzzled a bit by the description that says `Future` is a trait that must be implemented by a value in order to call `.await` on it, because the previous chapter "Async in depth" already covers that fact. So I attempted to fix it.
Besides, fixed a tiny typo as well.
