### PR TITLE
Minor grammar fixes

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -397,7 +397,7 @@ You can find the entire code [here][full].
 # Backpressure and bounded channels
 
 Whenever concurrency or queuing is introduced, it is important to ensure that the
-queueing is bounded and the system will gracefully handle load. Unbounded queues
+queueing is bounded and the system will gracefully handle the load. Unbounded queues
 will eventually fill up all available memory and cause the system to fail in
 unpredictable ways.
 
@@ -442,7 +442,7 @@ Concurrency and queuing must be explicitly introduced. Ways to do this include:
 * `join!`
 * `mpsc::channel`
 
-When doing so, take care to ensure total amount of concurrency is bounded. For
+When doing so, take care to ensure the total amount of concurrency is bounded. For
 example, when writing a TCP accept loop, ensure that the total number of open
 sockets is bounded. When using `mpsc::channel`, pick a manageable channel
 capacity. Specific bound values will be application specific.

--- a/content/tokio/tutorial/framing.md
+++ b/content/tokio/tutorial/framing.md
@@ -5,7 +5,7 @@ title: "Framing"
 We will now apply what we just learned about I/O and implement the Mini-Redis
 framing layer. Framing is the process of taking a byte stream and converting it
 to a stream of frames. A frame is a unit of data transmitted between two peers.
-The Redis protocol frame is as follows:
+The Redis protocol frame is defined as follows:
 
 ```rust
 use bytes::Bytes;

--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -2,7 +2,7 @@
 title: "I/O"
 ---
 
-I/O in Tokio operates in much the same way as `std`, but asynchronously. There
+I/O in Tokio operates in much the same way as in `std`, but asynchronously. There
 is a trait for reading ([`AsyncRead`]) and a trait for writing ([`AsyncWrite`]).
 Specific types implement these traits as appropriate ([`TcpStream`], [`File`],
 [`Stdout`]). [`AsyncRead`] and [`AsyncWrite`] are also implemented by a number


### PR DESCRIPTION
When following the tutorial I noticed some slight grammar mistakes, for instance a missing `the`.
Just don't merge yet, I'm not finished with the tutorial!

I am open to suggestions if you wish me to review more text or if you think my corrections are pointless / counterproductive.

### Todos:

- [  ] read the entire tutorial to review the whole text.