### PR TITLE
Add cargo commands to the tutorial

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -6,21 +6,29 @@ Now that we have learned a bit about concurrency with Tokio, let's apply this on
 the client side. Put the server code we wrote before into an explicit binary 
 file:
 
-    mkdir src/bin
-    mv src/main.rs src/bin/server.rs
+```
+mkdir src/bin
+mv src/main.rs src/bin/server.rs
+```
 
 and create a new binary file that will contain the client code:
 
-    touch src/bin/client.rs
+```
+touch src/bin/client.rs
+```
 
 In this file you will write this page's code. Whenever you want to run it,
 you will have to launch the server first in a separate terminal window:
 
-    cargo run --bin server
+```
+cargo run --bin server
+```
 
 And then the client, __separately__:
 
-    cargo run --bin client
+```
+cargo run --bin client
+```
 
 That being said, let's code!
 

--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -2,8 +2,29 @@
 title: "Channels"
 ---
 
-Now that we have learned some about concurrency with Tokio, let's apply this on
-the client side. Say we want to run two concurrent Redis commands. We can spawn
+Now that we have learned a bit about concurrency with Tokio, let's apply this on
+the client side. Put the server code we wrote before into an explicit binary 
+file:
+
+    mkdir src/bin
+    mv src/main.rs src/bin/server.rs
+
+and create a new binary file that will contain the client code:
+
+    touch src/bin/client.rs
+
+In this file you will write this page's code. Whenever you want to run it,
+you will have to launch the server first in a separate terminal window:
+
+    cargo run --bin server
+
+And then the client, __separately__:
+
+    cargo run --bin client
+
+That being said, let's code!
+
+Say we want to run two concurrent Redis commands. We can spawn
 one task per command. Then the two commands would happen concurrently.
 
 At first, we might try something like:

--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -6,27 +6,27 @@ Now that we have learned a bit about concurrency with Tokio, let's apply this on
 the client side. Put the server code we wrote before into an explicit binary 
 file:
 
-```
+```text
 mkdir src/bin
 mv src/main.rs src/bin/server.rs
 ```
 
 and create a new binary file that will contain the client code:
 
-```
+```text
 touch src/bin/client.rs
 ```
 
 In this file you will write this page's code. Whenever you want to run it,
 you will have to launch the server first in a separate terminal window:
 
-```
+```text
 cargo run --bin server
 ```
 
 And then the client, __separately__:
 
-```
+```text
 cargo run --bin client
 ```
 

--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -161,6 +161,19 @@ We will implement the echo server twice, using slightly different strategies.
 
 To start, we will implement the echo logic using the [`io::copy`][copy] utility.
 
+You can write up this code in a new binary file:
+
+    touch src/bin/echo-server-copy.rs
+
+That you can launch (or just check the compilation) with:
+
+    cargo run --bin echo-server-copy
+
+(We won't really try out the server, but feel free to build your own little client using
+[tokio::net::TcpStream example](https://docs.rs/tokio/1.4.0/tokio/net/struct.TcpStream.html#examples)
+with the proper socket address.)
+
+
 This is a TCP server and needs an accept loop. A new task is spawned to process
 each accepted socket.
 
@@ -324,6 +337,9 @@ async fn main() -> io::Result<()> {
 }
 # }
 ```
+
+(You can put this code into `src/bin/echo-server.rs` and launch it with
+`cargo run --bin echo-server`).
 
 Let's break it down. First, since the `AsyncRead` and `AsyncWrite` utilities are
 used, the extension traits must be brought into scope.

--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -163,13 +163,13 @@ To start, we will implement the echo logic using the [`io::copy`][copy] utility.
 
 You can write up this code in a new binary file:
 
-```
+```text
 touch src/bin/echo-server-copy.rs
 ```
 
 That you can launch (or just check the compilation) with:
 
-```
+```text
 cargo run --bin echo-server-copy
 ```
 

--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -163,16 +163,18 @@ To start, we will implement the echo logic using the [`io::copy`][copy] utility.
 
 You can write up this code in a new binary file:
 
-    touch src/bin/echo-server-copy.rs
+```
+touch src/bin/echo-server-copy.rs
+```
 
 That you can launch (or just check the compilation) with:
 
-    cargo run --bin echo-server-copy
+```
+cargo run --bin echo-server-copy
+```
 
-(We won't really try out the server, but feel free to build your own little client using
-[tokio::net::TcpStream example](https://docs.rs/tokio/1.4.0/tokio/net/struct.TcpStream.html#examples)
-with the proper socket address.)
-
+You will be able to try the server using a standard command-line tool such as `telnet`, or by writing
+a simple client like the one found in the documentation for [`tokio::net::TcpStream`][tcp_example].
 
 This is a TCP server and needs an accept loop. A new task is spawned to process
 each accepted socket.
@@ -449,3 +451,4 @@ Full code can be found [here][full_manual].
 [split]: https://docs.rs/tokio/1/tokio/io/fn.split.html
 [`TcpStream::split`]: https://docs.rs/tokio/1/tokio/net/struct.TcpStream.html#method.split
 [`into_split`]: https://docs.rs/tokio/1/tokio/net/struct.TcpStream.html#method.into_split
+[tcp_example]: https://docs.rs/tokio/1/tokio/net/struct.TcpStream.html#examples


### PR DESCRIPTION
As discussed in #503 , the tutorial becomes confusing around the Channel section. I have idenitfied it as a lack of instructions on structuring the code.

Following the pattern of instructions of the Spawning page (create an `examples/` directory, rename `main.rs` into it), I have edited the tutorial so it suggests to rename / create binary files in a `bin` directory: 

- `src/bin/server.rs`
- `src/bin/client.rs`
- `src/bin/echo-server-copy.rs`
- `src/bin/echo-server.rs`

With all the additional run instructions: `cargo run --bin …` and some verbosity.

I believe this will help learners like me who like to type code and tend to be reassured when told where and how.