### PR TITLE
Remove unneeded mutability on TcpListener

### DIFF
--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -186,7 +186,7 @@ use tokio::net::TcpListener;
 # fn dox() {
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let mut listener = TcpListener::bind("127.0.0.1:6142").await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:6142").await.unwrap();
 
     loop {
         let (mut socket, _) = listener.accept().await?;
@@ -306,7 +306,7 @@ use tokio::net::TcpListener;
 # fn dox() {
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let mut listener = TcpListener::bind("127.0.0.1:6142").await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:6142").await.unwrap();
 
     loop {
         let (mut socket, _) = listener.accept().await?;


### PR DESCRIPTION
Going to the tutorial I noticed this warning

```
warning: variable does not need to be mutable
 --> src\bin\echo-server.rs:6:9
  |
6 |     let mut listener = TcpListener::bind("127.0.0.1:6142").await.unwrap();
  |         ----^^^^^^^^
  |         |
  |         help: remove this `mut`
  |
  = note: `#[warn(unused_mut)]` on by default
```