### PR TITLE
Show fewer blogs in sidebar and link to an index

### DIFF
--- a/components/content.tsx
+++ b/components/content.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from "react-markdown/with-html";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import GithubSlugger from "github-slugger";
 import CustomBlocks from "remark-custom-blocks";
+import Link from "next/link";
 
 const CodeBlock = ({ language, value }) => {
   // Remove lines starting with `# `. This is code to make the doc tests pass
@@ -171,7 +172,11 @@ export default function Content({ menu, href, title, next, prev, body, mdPath })
     <>
       <div className="columns is-marginless tk-docs">
         <div className="column is-one-quarter tk-docs-nav">
-          <Menu href={href} menu={menu} />
+          <Menu href={href} menu={menu}>
+            <div className="all-posts-link">
+              <Link href="/blog"><a>More Blog Posts</a></Link>
+            </div>
+          </Menu>
         </div>
         <div className="column is-three-quarters tk-content">
           <section className="section content">

--- a/components/menu.jsx
+++ b/components/menu.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import classnames from "classnames";
+import Link from "next/link";
 
 const monthNames = [
   "January",
@@ -16,7 +17,7 @@ const monthNames = [
   "December",
 ];
 
-export default function Menu({ href, menu }) {
+export default function Menu({ href, menu, children }) {
   const groups = menu.map(({ key, title, nested }) => {
     return (
       <React.Fragment key={key}>
@@ -64,6 +65,7 @@ export default function Menu({ href, menu }) {
           <a>All Libraries</a>
         </p> */}
       </div>
+      {children}
     </aside>
   );
 }

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -1,0 +1,45 @@
+import * as api from "./api";
+
+let paths = null;
+
+function cachedPaths() {
+  if (paths === null) {
+    paths = api.getDateOrderedPaths("blog");
+  }
+  return paths;
+}
+
+export function getBlogPostsByYear({ limit } = {}) {
+  let count = 0;
+  return cachedPaths().reduce((years, post) => {
+    if (limit != null && count >= limit) {
+      return years
+    }
+    const date = new Date(post.date);
+    const year = date.getFullYear().toString();
+    if (!years[year]) {
+      years[year] = {
+        key: year,
+        title: year,
+        nested: [],
+      };
+    }
+    years[year].nested.push(post);
+    count++;
+    return years;
+  }, {});
+}
+
+export function getNextPost(afterSlug) {
+  let slugIndex = cachedPaths().findIndex((post) => post.key === afterSlug);
+  if (slugIndex > 0) {
+    return paths[slugIndex - 1]
+  }
+}
+
+export function getPreviousPost(beforeSlug) {
+  let slugIndex = cachedPaths().findIndex((post) => post.key === beforeSlug);
+  if (slugIndex !== -1 && slugIndex + 1 < paths.length) {
+    return paths[slugIndex + 1];
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,13 @@ module.exports = {
         return entries;
       };
     }
+
+    if (!isServer) {
+      config.node = {
+        fs: 'empty'
+      }
+    }
+
     return config;
   },
 };

--- a/pages/blog.jsx
+++ b/pages/blog.jsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import Layout from "../components/layout";
+import * as blog from "../lib/blog";
+import * as api from "../lib/api";
+
+export default function Blog({ app, postsByYear }) {
+  return (
+    <Layout title={"Blog Posts"} blog={app.blog}>
+      <div className="is-marginless tk-docs">
+        <div className="columns is-mobile is-centered">
+          <div className="column is-half tk-content">
+            <section className="section content">
+              <h1 className="title">Blog Posts</h1>
+              {Object.entries(postsByYear)
+                .reverse()
+                .map(([year, {key, title, nested}]) => (
+                  <YearPosts year={year} posts={nested} key={year} />
+                ))}
+            </section>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+function YearPosts({ year, posts }) {
+  return (
+    <div className="blog-year-posts">
+      <h2>{year}</h2>
+      <ul>
+        {posts.map((post) => (
+          <li>
+            <Link href={post.href}>
+              <a>{post.menuTitle || post.title}</a>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export async function getStaticProps() {
+  let postsByYear = blog.getBlogPostsByYear();
+  return await api.withAppProps({ props: { postsByYear }});
+}

--- a/pages/blog/[...slug].jsx
+++ b/pages/blog/[...slug].jsx
@@ -1,7 +1,10 @@
 import * as content from "../../lib/api";
+import * as blog from "../../lib/blog";
 import Page from "../../lib/page";
 
 export default Page;
+
+const SIDEBAR_POST_COUNT = 6;
 
 export async function getStaticPaths() {
   const paths = content.getDateOrderedPaths("blog").map((page) => {
@@ -16,52 +19,34 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ params: { slug } }) {
-  let paths = content.getDateOrderedPaths("blog");
-
-  let years = {};
+export async function getStaticProps({ params: { slug: slugParam } }) {
+  let slug = slugParam[0];
+  let postsByYear = blog.getBlogPostsByYear({
+    limit: SIDEBAR_POST_COUNT
+  });
 
   const page = content.loadPage(`blog/${slug}`);
-  let didSee = false;
 
-  let i = 0;
-  for (const p of paths) {
-    i += 1;
+  let next = blog.getNextPost(slug);
+  let previous = blog.getPreviousPost(slug);
 
-    delete p.body;
+  if (next) {
+    page.next = {
+      title: next.menuTitle || next.title,
+      href: next.href
+    };
+  }
 
-    if (p.href == page.href) {
-      didSee = true;
-    } else if (!didSee) {
-      page.next = {
-        title: p.menuTitle || p.title,
-        href: p.href,
-      };
-    } else if (!page.prev) {
-      page.prev = {
-        title: p.menuTitle || p.title,
-        href: p.href,
-      };
-    }
-
-    const date = new Date(p.date);
-
-    const year = date.getFullYear().toString();
-
-    if (!years[year]) {
-      years[year] = {
-        key: year,
-        title: year,
-        nested: [],
-      };
-    }
-
-    years[year].nested.push({ page: p });
+  if (previous) {
+    page.prev = {
+      title: previous.menuTitle || previous.title,
+      href: previous.href,
+    };
   }
 
   let menu = [];
 
-  for (const [, entry] of Object.entries(years)) {
+  for (const [, entry] of Object.entries(postsByYear)) {
     menu.push(entry);
   }
 

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -1005,3 +1005,17 @@ Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine
 .hljs-strong {
   font-weight: bold;
 }
+
+.all-posts-link {
+  margin: 0.5rem 0;
+  font-size: 0.9rem;
+
+  a {
+    font-weight: 500;
+    color: #c83895;
+  }
+}
+
+.blog-year-posts ul {
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
## Changes

This adds a new blog index at `/blog`. It lists all blog posts for all years.

A new link is added to the blog post page sidebar. Only the 6 most recent posts are shown in the sidebar.

I added a new `blog.js` module to encapsulate this logic, and pulled out most of the related code in `[...slug].js`.

I also added a fix for the "fs module not found" error that was popping up without related changes. This might be specific to my environment, and I can take that out if it's not wanted or too unrelated.


## Screenshots
### Blog Post Sidebar
![image](https://user-images.githubusercontent.com/271280/124340636-847eca80-db84-11eb-93bb-304b8e25b26c.png)

### Blog Index
![image](https://user-images.githubusercontent.com/271280/124340642-919bb980-db84-11eb-9c07-458efed4725e.png)
