### PR TITLE
fix blog index and link on mobile

### DIFF
--- a/components/menu.jsx
+++ b/components/menu.jsx
@@ -65,7 +65,8 @@ export default function Menu({ href, menu, children }) {
           <a>All Libraries</a>
         </p> */}
       </div>
-      {children}
+      {expanded && children}
+      <div className="is-hidden-mobile">{children}</div>
     </aside>
   );
 }

--- a/pages/blog.jsx
+++ b/pages/blog.jsx
@@ -8,7 +8,7 @@ export default function Blog({ app, postsByYear }) {
     <Layout title={"Blog Posts"} blog={app.blog}>
       <div className="is-marginless tk-docs">
         <div className="columns is-mobile is-centered">
-          <div className="column is-half tk-content">
+          <div className="column is-half-desktop tk-content">
             <section className="section content">
               <h1 className="title">Blog Posts</h1>
               {Object.entries(postsByYear)

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -1014,6 +1014,10 @@ Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine
     font-weight: 500;
     color: #c83895;
   }
+
+  @include mobile {
+    margin: 0 0.75rem;
+  }
 }
 
 .blog-year-posts ul {


### PR DESCRIPTION
@davidpdrsn caught that #584 looked incorrect on mobile. My bad, I should have tested that out.

This fixes the styling on mobile by making the index full-width and only showing the "All Posts" link when the TOC is expanded.

## Screenshots

### Blog Post
![image](https://user-images.githubusercontent.com/271280/124351774-4f956680-dbca-11eb-9c1f-8b1f8625ea8f.png)
![image](https://user-images.githubusercontent.com/271280/124351763-47d5c200-dbca-11eb-88d7-e0e72d424e04.png)

### Index
![image](https://user-images.githubusercontent.com/271280/124351786-56bc7480-dbca-11eb-8527-8f9287f6df01.png)
