### PR TITLE
only show "More Blog Posts" on blog routes

### DIFF
--- a/components/content.tsx
+++ b/components/content.tsx
@@ -168,14 +168,19 @@ export default function Content({ menu, href, title, next, prev, body, mdPath })
     return Heading(slugger, headings, props);
   };
 
+  let isBlogRoute = href.startsWith("/blog");
+
   return (
     <>
       <div className="columns is-marginless tk-docs">
         <div className="column is-one-quarter tk-docs-nav">
           <Menu href={href} menu={menu}>
-            <div className="all-posts-link">
-              <Link href="/blog"><a>More Blog Posts</a></Link>
-            </div>
+            { isBlogRoute && (
+                <div className="all-posts-link">
+                  <Link href="/blog"><a>More Blog Posts</a></Link>
+                </div>
+              )
+            }
           </Menu>
         </div>
         <div className="column is-three-quarters tk-content">


### PR DESCRIPTION
Fixes #586.

Only shows the "More Blog Posts" link if the current route begins with `/blog`.

## Screenshots
### Blog Route
![image](https://user-images.githubusercontent.com/271280/124589260-ca0ef200-de27-11eb-956d-7a5b76430413.png)

### Tutorial Route
![image](https://user-images.githubusercontent.com/271280/124589312-dabf6800-de27-11eb-9afb-c7aade61b726.png)
