### PR TITLE
add netlify link in footer

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -59,6 +59,11 @@ export default function Footer() {
             </div>
           </div>
         </div>
+        <div className="container has-text-centered tk-sponsored">
+          <p>
+            Hosted by <a href="https://netlify.com" rel="sponsored nofollow">Netlify</a>
+          </p>
+        </div>
       </div>
     </footer>
   );

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -835,12 +835,18 @@ a:active {
   }
 
   .tk-footer-libs,
-  .tk-footer-libs a {
+  .tk-footer-libs a,
+  .tk-sponsored,
+  .tk-sponsored a {
     color: white;
   }
 
   .tk-lib-name {
     font-weight: 600;
+  }
+
+  .tk-sponsored {
+    margin-top: 2rem;
   }
 }
 


### PR DESCRIPTION
This is required to be on the OSS plan, but we lost the link in the redesign.