### PR TITLE
Don't use old link for bridging article

### DIFF
--- a/content/tokio/tutorial/index.md
+++ b/content/tokio/tutorial/index.md
@@ -107,7 +107,7 @@ simultaneously, there are also some use-cases where Tokio is not a good fit.
 
 [rayon]: https://docs.rs/rayon/
 [reqwest]: https://docs.rs/reqwest/
-[bridging]: /tokio/tutorial/bridging
+[bridging]: /tokio/topics/bridging
 
 # Getting Help
 


### PR DESCRIPTION
This url was changed in #590. The link still works because I added a redirect, but we should prefer the direct link.