### PR TITLE
To not -> Not to

### DIFF
--- a/content/tokio/tutorial/index.md
+++ b/content/tokio/tutorial/index.md
@@ -81,7 +81,7 @@ to their needs.
 
 [work-stealing]: https://en.wikipedia.org/wiki/Work_stealing
 
-# When to not use Tokio
+# When not to use Tokio
 
 Although Tokio is useful for many projects that need to do a lot of things
 simultaneously, there are also some use-cases where Tokio is not a good fit.


### PR DESCRIPTION
Not to is a split infinitive and is historically frowned upon. This simple change improves readability greatly (source: it's 12 in the morning)