### PR TITLE
chore: update Rust version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup install nightly-2020-08-22
+        run: rustup install nightly-2021-03-15
 
       - name: Build dependencies
-        run: cargo +nightly-2020-08-22 build
+        run: cargo +nightly-2021-03-15 build
         working-directory: doc-test
         continue-on-error: true
 
       - name: Actually run the tests
-        run: cargo +nightly-2020-08-22 test
+        run: cargo +nightly-2021-03-15 test
         working-directory: doc-test
   tutorial-code:
     name: Test tutorial-code directory


### PR DESCRIPTION
Update version of Rust in CI to avoid running in to https://github.com/hawkw/sharded-slab/issues/60 in CI.