### PR TITLE
Center `Getting Started` button on landing page

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -37,9 +37,11 @@ const Hero: FC = () => (
                   network applications. It leverages Rust's ownership and
                   concurrency model to ensure thread safety. */}
           </h2>
-          <a href={gettingStarted} className="button is-link is-medium">
-            Get Started
-          </a>
+          <div className="has-text-centered">
+            <a href={gettingStarted} className="button is-link is-medium">
+              Get Started
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -37,7 +37,7 @@ const Hero: FC = () => (
                   network applications. It leverages Rust's ownership and
                   concurrency model to ensure thread safety. */}
           </h2>
-          <div className="has-text-centered">
+          <div className="has-text-centered-mobile">
             <a href={gettingStarted} className="button is-link is-medium">
               Get Started
             </a>


### PR DESCRIPTION
Closes #437.

Alternative solution is to remove `has-text-left-mobile` instead of change in the pr. 
https://github.com/tokio-rs/website/blob/1d940c88f160c2fe0d657a6e43e10a406eb25a89/components/hero.tsx#L25


How it looks with only button centered.
![just-button](https://user-images.githubusercontent.com/50183564/132817818-c07bd237-790c-4eeb-8ec7-0f1d60149e3d.png)

How it looks with entire container centered on mobile.
![everything](https://user-images.githubusercontent.com/50183564/132817820-14419b8d-d6f0-4267-8c16-080e3d553b3f.png)

I've found everything centered a bit harder to read so I didn't include it. But if entire container centered looks better I'll change it.


