### PR TITLE
Add unwrap method to remove compile-time warnings

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -225,10 +225,10 @@ let manager = tokio::spawn(async move {
 
         match cmd {
             Get { key } => {
-                client.get(&key).await;
+                client.get(&key).await.unwrap();
             }
             Set { key, val } => {
-                client.set(&key, val).await;
+                client.set(&key, val).await.unwrap();
             }
         }
     }


### PR DESCRIPTION
```
warning: unused `Result` that must be used
  --> src/bin/client.rs:25:21
   |
25 |                     client.get(&key).await;
   |                     ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: this `Result` may be an `Err` variant, which should be handled

warning: unused `Result` that must be used
  --> src/bin/client.rs:28:21
   |
28 |                     client.set(&key, value).await;
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this `Result` may be an `Err` variant, which should be handled

warning: `my-redis` (bin "client") generated 2 warnings
```