### PR TITLE
Rename buffer to file in write_all example

### DIFF
--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -109,9 +109,9 @@ use tokio::fs::File;
 # fn dox() {
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let mut buffer = File::create("foo.txt").await?;
+    let mut file = File::create("foo.txt").await?;
 
-    buffer.write_all(b"some bytes").await?;
+    file.write_all(b"some bytes").await?;
     Ok(())
 }
 # }


### PR DESCRIPTION
I think file is more reasonable name in this case.