### PR TITLE
blog: fix up headers in console blog post

### DIFF
--- a/content/blog/2021-12-announcing-tokio-console.md
+++ b/content/blog/2021-12-announcing-tokio-console.md
@@ -4,7 +4,6 @@ title: "Announcing Tokio Console 0.1"
 description: "December 17, 2021"
 ---
 
-# Announcing Tokio Console 0.1
 
 Today, we, the Tokio team, are announcing the initial release of Tokio Console
 ([Github](github.com/tokio-rs/console)), enabling Rust developers to gain deeper
@@ -81,6 +80,8 @@ says:
 > progress as expected, `tokio-console` was able to immediately surface that a
 > lack of wake-ups was the cause, providing insight that ultimately lead to
 > discovering unexpected scheduling behavior with Tokio.
+
+# Getting Started
 
 To get started with the console, run `cargo install tokio-console`, then follow
 the instructions to [add `console-subscriber`][subscriber doc] to your async

--- a/content/blog/2021-12-announcing-tokio-console.md
+++ b/content/blog/2021-12-announcing-tokio-console.md
@@ -149,7 +149,7 @@ on [issues](github.com/tokio-rs/console) and send pull requests our way!
 [#129]: https://github.com/tokio-rs/console/issues/129
 
 
-## Thanks to
+# Thanks to
 
 * Sean McArthur
 * Zahari Dichev


### PR DESCRIPTION
Currently, the table of contents for the console blog post looks kind
of weird: "thanks to" is a subsection of "roadmap", and "announcing
tokio-console 0.1" appears twice, once for the post title and once
for the markdown H1 at the top of the post.

![image](https://user-images.githubusercontent.com/2796466/146583416-9d172523-af84-4411-b1fd-75a0f3eec5de.png)

This PR fixes these cosmetic issues. I made "thanks to" an H1 header so
it isn't a subsection of the "roadmap" section, and removed the
duplicate title. I also added a section header for how to get started
using the console.