### PR TITLE
Update language in spawning tutorial

### DIFF
--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -177,7 +177,7 @@ thousands, if not millions of tasks.
 
 ## `'static` bound
 
-When you spawn a task on the Tokio runtime, its type must be `'static`. This
+When you spawn a task on the Tokio runtime, its lifetime must be `'static`. This
 means that the spawned task must not contain any references to data owned
 outside the task.
 

--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -177,7 +177,7 @@ thousands, if not millions of tasks.
 
 ## `'static` bound
 
-When you spawn a task on the Tokio runtime, its lifetime must be `'static`. This
+When you spawn a task on the Tokio runtime, its type's lifetime must be `'static`. This
 means that the spawned task must not contain any references to data owned
 outside the task.
 


### PR DESCRIPTION
I am a newcomer to rust and hadn't learned what `'static` meant. Adding the word 'lifetime' would help clarify the keyword for anyone else in my position.