### PR TITLE
Update select.md, fix example error

### DIFF
--- a/content/tokio/tutorial/select.md
+++ b/content/tokio/tutorial/select.md
@@ -513,7 +513,7 @@ async fn main() {
             else => { break }
         };
 
-        println!("Got {}", msg);
+        println!("Got {:?}", msg);
     }
 
     println!("All channels have been closed.");


### PR DESCRIPTION
error[E0277]: `()` doesn't implement `std::fmt::Display`.

We use the display of the Debug trait instead.