### PR TITLE
Remove `await` from non-async function call

### DIFF
--- a/content/blog/2021-05-14-inventing-the-service-trait.md
+++ b/content/blog/2021-05-14-inventing-the-service-trait.md
@@ -53,8 +53,8 @@ impl Server {
             let request = read_http_request(&mut connection).await?;
 
             task::spawn(async move {
-                // Await the future returned by `handler`
-                let response = handler(request).await;
+                // Call the handler provided by the user
+                let response = handler(request);
 
                 write_http_response(connection, response).await?;
             });


### PR DESCRIPTION
At this point in the tutorial the handler is just `F: Fn(HttpRequest) -> HttpResponse` so we can't `.await` it.