### PR TITLE
chore: switch CI doc-tests to run using stable channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup install nightly-2021-03-15
+        run: rustup update stable
 
       - name: Build dependencies
-        run: cargo +nightly-2021-03-15 build
+        run: cargo build
         working-directory: doc-test
         continue-on-error: true
 
       - name: Actually run the tests
-        run: cargo +nightly-2021-03-15 test
+        run: cargo test
         working-directory: doc-test
   tutorial-code:
     name: Test tutorial-code directory

--- a/doc-test/build.rs
+++ b/doc-test/build.rs
@@ -93,7 +93,7 @@ impl Level {
                 .replace("-", "_");
 
             self.write_space(dst, level);
-            write!(dst, "#[doc(include = \"{}\")]\n", file.display())?;
+            write!(dst, "#[doc = include_str!(\"{}\")]\n", file.display())?;
             self.write_space(dst, level);
             write!(dst, "pub fn {}_md() {{}}\n", stem)?;
             // write!(dst, "doc_comment!(include_str!(\"{}\"));\n", file.display())?;

--- a/doc-test/src/lib.rs
+++ b/doc-test/src/lib.rs
@@ -1,3 +1,1 @@
-#![feature(external_doc)]
-
 include!(concat!(env!("OUT_DIR"), "/doctests.rs"));


### PR DESCRIPTION
This patch switches the CI for doc-tests to run using stable.