### PR TITLE
Added a small explanation of a change to Bytes

### DIFF
--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -113,7 +113,9 @@ faster alternative to `std::sync::Mutex`.
 
 The process function no longer initializes a `HashMap`. Instead, it takes the
 shared handle to the `HashMap` as an argument. It also needs to lock the
-`HashMap` before using it.
+`HashMap` before using it. Remember that the value's type for the HashMap 
+is now `Bytes` (which we can cheaply clone), so this needs to be changed
+as well.
 
 ```rust
 use tokio::net::TcpStream;


### PR DESCRIPTION
The "Update process()" section mentions that we indeed need to pass the `HashMap` as an argument. As I was going through those changes, the change from `Vec<u8>` to `Bytes` went under my radar (needs a change in line 138), and although it's simple enough to detect, I thought it would make sense to include this short explanation.

### How did I test this?

Ran the indicated tests in the README.md locally:

```
# in doc-test
cargo +nightly test

# in tutorial-code
cargo test --all
```

Do notice that the doc tests required me to run with `RUSTFLAGS="--cfg tokio_unstable"`, I can update the README as well to reflect this change if that's OK.