### PR TITLE
Minor tweaks in the README to explain setting up the server and running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ locally.
 ### Getting Started
 
 The website is built using [Next.js] paired with the [Bulma] CSS framework.
-First, make sure you have NPM installed. Next, start the development server:
+You'll need NPM to install the required packages with:
+
+```bash
+npm install
+```
+
+Next, start the development server:
 
 ```bash
 npm run dev
@@ -54,8 +60,8 @@ terms or conditions.
 
 You can run our tests by running the commands:
 ```
-# in doc-test
-cargo +nightly test
+# in doc-test (unstable APIs are needed by some tests)
+RUSTFLAGS="--cfg tokio_unstable" cargo +nightly test
 
 # in tutorial-code
 cargo test --all


### PR DESCRIPTION
As explained in a previous [PR](https://github.com/tokio-rs/website/pull/666), when running

```bash
cargo +nightly test
```

The tests failed because a doc-test needs `tokio-unstable`. I added this flag in the instructions, and add what felt to me like a better explanation of how to set up the local server.

## How did I test this?

Followed the testing instructions again.

Markdown in my IDE looked pretty for the doc changes.