### PR TITLE
Update some docs.rs references to /latest/

### DIFF
--- a/content/blog/2018-03-timers.md
+++ b/content/blog/2018-03-timers.md
@@ -117,9 +117,9 @@ And with that, have a great weekend!
 [new release]: https://crates.io/crates/tokio/0.1.5
 [wheel]: http://www.cs.columbia.edu/~nahum/w6998/papers/sosp87-timing-wheels.pdf
 [2]: https://crates.io/crates/tokio-timer/0.2.0
-[delay]: https://docs.rs/tokio/0.1/tokio/timer/struct.Delay.html
-[timeout]: https://docs.rs/tokio/0.1/tokio/timer/struct.Timeout.html
-[interval]: https://docs.rs/tokio/0.1/tokio/timer/struct.Interval.html
+[delay]: https://docs.rs/tokio/latest/tokio/timer/struct.Delay.html
+[timeout]: https://docs.rs/tokio/latest/tokio/timer/struct.Timeout.html
+[interval]: https://docs.rs/tokio/latest/tokio/timer/struct.Interval.html
 
-[api]: https://docs.rs/tokio/0.1/tokio/timer/index.html
-[runtime]: https://docs.rs/tokio/0.1/tokio/runtime/index.html
+[api]: https://docs.rs/tokio/latest/tokio/timer/index.html
+[runtime]: https://docs.rs/tokio/latest/tokio/runtime/index.html

--- a/content/blog/2018-05-tokio-fs.md
+++ b/content/blog/2018-05-tokio-fs.md
@@ -78,9 +78,9 @@ The release also includes a ["current thread"][rt] version of the runtime
 but runs all components on the current thread. This allows running futures that
 do not implement `Send`.
 
-[fs]: https://docs.rs/tokio/0.1/tokio/fs/index.html
-[`file`]: https://docs.rs/tokio/0.1/tokio/fs/struct.File.html
-[in]: https://docs.rs/tokio/0.1/tokio/io/fn.stdin.html
-[out]: https://docs.rs/tokio/0.1/tokio/io/fn.stdout.html
-[`blocking`]: https://docs.rs/tokio-threadpool/0.1/tokio_threadpool/fn.blocking.html
-[rt]: https://docs.rs/tokio/0.1/tokio/runtime/current_thread/index.html
+[fs]: https://docs.rs/tokio/latest/tokio/fs/index.html
+[`file`]: https://docs.rs/tokio/latest/tokio/fs/struct.File.html
+[in]: https://docs.rs/tokio/latest/tokio/io/fn.stdin.html
+[out]: https://docs.rs/tokio/latest/tokio/io/fn.stdout.html
+[`blocking`]: https://docs.rs/tokio-threadpool/latest/tokio_threadpool/fn.blocking.html
+[rt]: https://docs.rs/tokio/latest/tokio/runtime/current_thread/index.html

--- a/content/blog/2018-08-incremental-improvements.md
+++ b/content/blog/2018-08-incremental-improvements.md
@@ -29,7 +29,7 @@ review and improve the crate.
 Thanks goes to: [@dekellum], [@matsadler], [@debris], [@mati865], [@lovebug356],
 [@bryanburgers], [@shepmaster].
 
-[fs]: https://docs.rs/tokio/0.1.8/tokio/fs/index.html
+[fs]: https://docs.rs/tokio/latest/tokio/fs/index.html
 [pr]: https://github.com/tokio-rs/tokio/pull/494
 
 ## Concurrency improvements

--- a/content/blog/2019-12-compat.md
+++ b/content/blog/2019-12-compat.md
@@ -253,7 +253,7 @@ considered idle. See [this section][idle] in the documentation for details.
 [blocking]: https://docs.rs/tokio-threadpool/0.1.16/tokio_threadpool/fn.blocking.html
 [`task::block_in_place`]: https://docs.rs/tokio/0.2.4/tokio/task/fn.block_in_place.html
 [`task::spawn_blocking`]: https://docs.rs/tokio/0.2.4/tokio/task/fn.spawn_blocking.html
-[`tokio::fs`]: https://docs.rs/tokio/0.1.22/tokio/fs/index.html
+[`tokio::fs`]: https://docs.rs/tokio/latest/tokio/fs/index.html
 [blocking-compat]: https://docs.rs/tokio-compat/0.1.0/tokio_compat/runtime/index.html#blocking
 [idle]: https://docs.rs/tokio-compat/0.1.0/tokio_compat/runtime/index.html#shutting-down
 


### PR DESCRIPTION
When users search Google for certain terms, like [tokio delay], they wind up on outdated docs for tokio 0.1:
https://docs.rs/tokio/0.1/tokio/timer/struct.Delay.html.

On the docs.rs team we're working on improving things so users are more likely to find the latest docs on Google. It looks like certain old blog posts on tokio.rs are causing these tokio 0.1 doc URLs to rank highly, so I'd like to bump them to use the new /latest/ format.