### PR TITLE
fix(blog): update default instrument level to `info`

### DIFF
--- a/content/tokio/topics/tracing.md
+++ b/content/tokio/topics/tracing.md
@@ -152,7 +152,7 @@ fn trace_me(a: u32, b: u32) -> u32 {
 
 Each invocation of `trace_me` will emit a `tracing` Span that:
 
-1. has a verbosity [level] of `trace` (the greatest verbosity),
+1. has a verbosity [level] of `info` (the "middle ground" verbosity),
 2. is named `trace_me`,
 3. has fields `a` and `b`, whose values are the arguments of `trace_me`
 
@@ -174,7 +174,6 @@ use tracing::instrument;
 impl Handler {
     /// Process a single connection.
     #[instrument(
-        level = "info",
         name = "Handler::run",
         skip(self),
         fields(


### PR DESCRIPTION
> Unless overriden, a span with the [INFO](https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.INFO) [level](https://docs.rs/tracing/latest/tracing/struct.Level.html) will be generated. The generated span’s name will be the name of the function. By default, all arguments to the function are included as fields on the span. Arguments that are tracing [primitive types](https://docs.rs/tracing/latest/tracing/field/trait.Value.html#foreign-impls) implementing the [Value trait](https://docs.rs/tracing/latest/tracing/field/trait.Value.html.) will be recorded as fields of that type. Types which do not implement Value will be recorded using [std::fmt::Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html).

See: [docs on `tracing::instrument`](https://docs.rs/tracing/latest/tracing/attr.instrument.html#)