### PR TITLE
Use a raw string literal when including markdown files during doc test creation

### DIFF
--- a/doc-test/build.rs
+++ b/doc-test/build.rs
@@ -93,7 +93,7 @@ impl Level {
                 .replace("-", "_");
 
             self.write_space(dst, level);
-            write!(dst, "#[doc = include_str!(\"{}\")]\n", file.display())?;
+            write!(dst, "#[doc = include_str!(r\"{}\")]\n", file.display())?;
             self.write_space(dst, level);
             write!(dst, "pub fn {}_md() {{}}\n", stem)?;
             // write!(dst, "doc_comment!(include_str!(\"{}\"));\n", file.display())?;


### PR DESCRIPTION
When trying to run the tests on Windows, the compilation fails, because the paths to the markdown files get canonicalized to contain backslashes (e.g. `\\?\D:\tokio-rs\website\content\tokio\index.md`). This leads to an `unknown character escape` error. Using a raw string literal fixes this by having rustc interpret the path as-is.