### PR TITLE
Remove extraneous pipe character within info block in spawning.md

### DIFF
--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -103,7 +103,7 @@ need to add some concurrency.
 > two tasks, then you are working on both tasks concurrently, but not in
 > parallel. For it to qualify as parallel, you would need two people, one
 > dedicated to each task.
-|
+>
 > One of the advantages of using Tokio is that asynchronous code allows you to
 > work on many tasks concurrently, without having to work on them in parallel
 > using ordinary threads. In fact, Tokio can run many tasks concurrently on a


### PR DESCRIPTION
This commit removes an extraneous pipe character, as well as inserts a newline between distinct two thoughts for better readability.

Before this change, the paragraph looked like this:

![image](https://user-images.githubusercontent.com/1342360/229238352-005e465d-16fb-43d2-9451-9c14f90ed792.png)

Notice the extraneous pipe (`|`) character. After this change, it looks like:

![image](https://user-images.githubusercontent.com/1342360/229238528-a8ecd467-6269-41cb-9007-549bf72ab153.png)
