### PR TITLE
Fix side navigation menu overflowing on narrow screens

### DIFF
--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -520,7 +520,11 @@ a:active {
     }
 
     @include tablet {
-      padding: 4rem 0 0 1rem;
+      padding: 4rem 0 4rem 1rem;
+      top: 0;
+      position: sticky;
+      overflow-y: auto;
+      height: 100vh;
     }
   }
 
@@ -528,13 +532,10 @@ a:active {
     font-size: $menu-font-size;
     position: relative;
     z-index: 2;
-
+    
     @include tablet {
-      position: sticky;
-      top: 4rem;
       max-width: 280px;
       margin-left: auto;
-      padding-bottom: 4rem;
     }
 
     @include mobile {


### PR DESCRIPTION
Found this a little annoying that on my 13'' MacBook vertical menu overflows and it's impossible to scroll it until the end of the page.

![before](https://user-images.githubusercontent.com/18420141/232052638-88d9365e-1ba9-4c6b-b543-5d72c8c4d9cb.gif)

So I made the container sticky (instead of nested `aside` element) and overflow-able with scroll. Also rearranged paddings so that they are on container level too, I think it's slightly better for how the page feels.

![after](https://user-images.githubusercontent.com/18420141/232053561-caf126c9-68ce-44e4-99b8-bb5f86ac342c.gif)
