### PR TITLE
Dropping repetitive text

### DIFF
--- a/content/tokio/tutorial/hello-tokio.md
+++ b/content/tokio/tutorial/hello-tokio.md
@@ -247,4 +247,3 @@ utilities, multiple scheduler types, etc). Not all applications need all
 functionality. When attempting to optimize compile time or the end application
 footprint, the application can decide to opt into **only** the features it uses.
 
-For now, use the "full" feature when depending on Tokio.


### PR DESCRIPTION
The Line 1 and Line 2 conveys the same idea of using full feature flag for this tutorial. Line 1. When depending on Tokio for this tutorial, the `full` feature flag is enabled. Line 2. For now, use the "full" feature when depending on Tokio.