### PR TITLE
Update index.md

### DIFF
--- a/content/tokio/topics/index.md
+++ b/content/tokio/topics/index.md
@@ -2,7 +2,7 @@
 title: "Topics"
 ---
 
-The Tokio topics pages has self-contained articles related to various topics
+This section has self-contained articles related to various topics
 that come up when writing asynchronous applications.
 
 The currently available topics articles are:


### PR DESCRIPTION
The context "Tokio Topics" is self explanatory. By removing it making the language of text more formal.