### PR TITLE
fix typo `though` -> `thought`

### DIFF
--- a/content/blog/2019-10-scheduler.md
+++ b/content/blog/2019-10-scheduler.md
@@ -77,7 +77,7 @@ assigning CPU time -- a global resource -- to the task.
 
 The article discusses user-space schedulers, i.e., schedulers that run on top of
 operating system threads (which, in turn, are powered by a kernel land
-scheduler). The Tokio scheduler executes Rust futures, which can be though of as
+scheduler). The Tokio scheduler executes Rust futures, which can be thought of as
 "asynchronous green threads". This is the [M:N threading][mn] pattern where many
 user land tasks are multiplexed on a few operating system threads.
 


### PR DESCRIPTION
Hi everyone,

While reading through the blog, came across this typo
![Screenshot 2023-06-06 at 12 12 22 PM](https://github.com/tokio-rs/website/assets/48803246/65b03d9e-5b58-4129-98f5-2232994828c6)
