### PR TITLE
fix: mistake in docs, change "multi-consumer" to "single-consumer"

### DIFF
--- a/content/tokio/glossary.md
+++ b/content/tokio/glossary.md
@@ -198,7 +198,7 @@ purpose.
 - [watch]: single-producer, multi-consumer. Many values can be sent, but no
   history is kept. Receivers only see the most recent value.
 
-If you need a multi-producer multi-consumer channel where only one consumer sees
+If you need a multi-producer single-consumer channel where only one consumer sees
 each message, you can use the [`async-channel`] crate.
 
 There are also channels for use outside of asynchronous Rust, such as


### PR DESCRIPTION
I was following the content on [channels](https://tokio.rs/tokio/tutorial/channels), and there seems to be a mistake:

We seem to be talking about "multi-producer single-consumer"(mpsc) but have mentioned "multi-producer multi-consumer"(broadcast channels) instead!

NOTE: if this is replicated anywhere else, then we should fix that as well!

<img width="801" alt="image" src="https://github.com/tokio-rs/website/assets/41180869/b41b6120-3670-4a18-b8f6-c25d20f15821">
