### PR TITLE
fix: link to tracing next steps page

### DIFF
--- a/content/tokio/topics/index.md
+++ b/content/tokio/topics/index.md
@@ -10,4 +10,4 @@ The currently available topics articles are:
  * [Bridging with sync code](/tokio/topics/bridging)
  * [Graceful shutdown](/tokio/topics/shutdown)
  * [Getting started with Tracing](/tokio/topics/tracing)
- * [Next steps with Tracing](/tokio/topics/tokio-next-steps)
+ * [Next steps with Tracing](/tokio/topics/tracing-next-steps)


### PR DESCRIPTION
**PR Summary**:
PR contains a small fix to link that should point to the "tracing next steps" (instead of "tokio next steps").