### PR TITLE
Remove suggestion for parking_lot mutexes

### DIFF
--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -92,10 +92,10 @@ async fn main() {
 
 ## On using `std::sync::Mutex`
 
-Note, `std::sync::Mutex` and **not** `tokio::sync::Mutex` is used to guard the
-`HashMap`. A common error is to unconditionally use `tokio::sync::Mutex` from
-within async code. An async mutex is a mutex that is locked across calls to
-`.await`.
+Note that `std::sync::Mutex` and **not** `tokio::sync::Mutex` is used to guard
+the `HashMap`. A common error is to unconditionally use `tokio::sync::Mutex`
+from within async code. An async mutex is a mutex that is locked across calls
+to `.await`.
 
 A synchronous mutex will block the current thread when waiting to acquire the
 lock. This, in turn, will block other tasks from processing. However, switching
@@ -104,10 +104,7 @@ synchronous mutex internally.
 
 As a rule of thumb, using a synchronous mutex from within asynchronous code is
 fine as long as contention remains low and the lock is not held across calls to
-`.await`. Additionally, consider using [`parking_lot::Mutex`][parking_lot] as a
-faster alternative to `std::sync::Mutex`.
-
-[parking_lot]: https://docs.rs/parking_lot/0.10.2/parking_lot/type.Mutex.html
+`.await`.
 
 # Update `process()`
 


### PR DESCRIPTION
Lately the std mutex has perfectly fine performance comparable to parking_lot and unlike parking_lot, has lock poisoning. Thus it seems more reasonable to not explicitly recommend it, and if people have one of the specialized use cases where lock choice is super important, they probably know that.

See also: https://hachyderm.io/@rain/110738343644683050