### PR TITLE
Clarify variable naming in async.md

### DIFF
--- a/content/tokio/tutorial/async.md
+++ b/content/tokio/tutorial/async.md
@@ -792,7 +792,7 @@ use std::thread;
 async fn delay(dur: Duration) {
     let when = Instant::now() + dur;
     let notify = Arc::new(Notify::new());
-    let notify2 = notify.clone();
+    let notify_clone = notify.clone();
 
     thread::spawn(move || {
         let now = Instant::now();
@@ -801,7 +801,7 @@ async fn delay(dur: Duration) {
             thread::sleep(when - now);
         }
 
-        notify2.notify_one();
+        notify_clone.notify_one();
     });
 
 


### PR DESCRIPTION
It's a little bit confusing for a newcomer that notify one method is called on notify two -- it gives wrong hint/intuition to some readers, so it worth to choose a name which won't suggest such semantic, which isn't there.

Looks like this part of code is only in tutorial text, and nothing to sync in the supplementary code.