### PR TITLE
Apply markdown lint and formatting

### DIFF
--- a/content/tokio/glossary.md
+++ b/content/tokio/glossary.md
@@ -61,13 +61,12 @@ combined part is said to be "in the same task".
 Multiple tasks are required for parallelism, but it is possible to concurrently
 do multiple things on one task using tools such as `join!`.
 
-[`tokio::spawn`]: https://docs.rs/tokio/1/tokio/fn.spawn.html
 [`Runtime::block_on`]: https://docs.rs/tokio/1/tokio/runtime/struct.Runtime.html#method.block_on
 [`join!`]: https://docs.rs/tokio/1/tokio/macro.join.html
 
 ## Spawning
 
-Spawning is when the `tokio::spawn` function is used to create a new task. It
+Spawning is when the [`tokio::spawn`] function is used to create a new task. It
 can also refer to creating new thread with [`std::thread::spawn`].
 
 [`tokio::spawn`]: https://docs.rs/tokio/1/tokio/fn.spawn.html

--- a/content/tokio/topics/bridging.md
+++ b/content/tokio/topics/bridging.md
@@ -371,14 +371,12 @@ This example could be configured in many ways. For instance, you could use a
 the opposite direction to send a response to the spawner. When you spawn a
 runtime in this way, it is a type of [actor].
 
-
 [`Runtime`]: https://docs.rs/tokio/1/tokio/runtime/struct.Runtime.html
 [`block_on`]: https://docs.rs/tokio/1/tokio/runtime/struct.Runtime.html#method.block_on
 [`spawn`]: https://docs.rs/tokio/1/tokio/runtime/struct.Runtime.html#method.spawn
 [`spawn_blocking`]: https://docs.rs/tokio/1/tokio/task/fn.spawn_blocking.html
 [`multi_thread`]: https://docs.rs/tokio/1/tokio/runtime/struct.Builder.html#method.new_multi_thread
 [`current_thread`]: https://docs.rs/tokio/1/tokio/runtime/struct.Builder.html#method.new_current_thread
-[`worker_threads`]: https://docs.rs/tokio/1/tokio/runtime/struct.Builder.html#method.worker_threads
 [`enable_all`]: https://docs.rs/tokio/1/tokio/runtime/struct.Builder.html#method.enable_all
 [`JoinHandle`]: https://docs.rs/tokio/1/tokio/task/struct.JoinHandle.html
 [`tokio::sync::mpsc`]: https://docs.rs/tokio/1/tokio/sync/mpsc/index.html

--- a/content/tokio/topics/shutdown.md
+++ b/content/tokio/topics/shutdown.md
@@ -69,23 +69,23 @@ async fn main() {
 
 ## Telling things to shut down
 
-When you want to tell one or more tasks to shut down, you can use [Cancellation 
-Tokens][cancellation-tokens]. These tokens allow you to notify tasks that they 
-should terminate themselves in response to a cancellation request, making it 
+When you want to tell one or more tasks to shut down, you can use [Cancellation
+Tokens][cancellation-tokens]. These tokens allow you to notify tasks that they
+should terminate themselves in response to a cancellation request, making it
 easy to implement graceful shutdowns.
 
-To share a `CancellationToken` between several tasks, you must clone it. This is due 
-to the single ownership rule that requires that each value has a single owner. When 
-cloning a token, you get another token that's indistinguishable from the original; 
-if one is cancelled, then the other is also cancelled. You can make as many clones 
+To share a `CancellationToken` between several tasks, you must clone it. This is due
+to the single ownership rule that requires that each value has a single owner. When
+cloning a token, you get another token that's indistinguishable from the original;
+if one is cancelled, then the other is also cancelled. You can make as many clones
 as you need, and when you call `cancel` on one of them, they're all cancelled.
 
 Here are the steps to use `CancellationToken` in multiple tasks:
+
 1. First, create a new `CancellationToken`.
 2. Then, create a clone of the original `CancellationToken` by calling the `clone` method on the original token. This will create a new token that can be used by another task.
 3. Pass the original or cloned token to the tasks that should respond to cancellation requests.
 4. When you want to shut down the tasks gracefully, call the `cancel` method on the original or cloned token. Any task listening to the cancellation request on the original or cloned token will be notified to shut down.
-
 
 Here is code snippet showcasing the above mentioned steps:
 
@@ -121,9 +121,9 @@ tokio::spawn(async move {
 task1_handle.await.unwrap()
 ```
 
-With Cancellation Tokens, you don't have to shut down a task immediately when 
-the token is cancelled. Instead, you can run a shutdown procedure before 
-terminating the task, such as flushing data to a file or database, or sending 
+With Cancellation Tokens, you don't have to shut down a task immediately when
+the token is cancelled. Instead, you can run a shutdown procedure before
+terminating the task, such as flushing data to a file or database, or sending
 a shutdown message on a connection.
 
 ## Waiting for things to finish shutting down
@@ -173,7 +173,6 @@ before waiting for the channel to be closed.
 [an mpsc channel]: https://docs.rs/tokio/1/tokio/sync/mpsc/index.html
 [select]: https://docs.rs/tokio/1/tokio/macro.select.html
 [cancellation-tokens]: https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html
-[watch]: https://docs.rs/tokio/1/tokio/sync/watch/index.html
 [shutdown.rs]: https://github.com/tokio-rs/mini-redis/blob/master/src/shutdown.rs
 [server.rs]: https://github.com/tokio-rs/mini-redis/blob/master/src/server.rs
 [mini-redis]: https://github.com/tokio-rs/mini-redis/

--- a/content/tokio/topics/tracing-next-steps.md
+++ b/content/tokio/topics/tracing-next-steps.md
@@ -9,7 +9,7 @@ of an application’s spans and events. It can also represent "resources" that t
 Tokio runtime has created, such as Tasks. It's essential for understanding
 performance issues during the development process.
 
-For instance, to use tokio-console in [the mini-redis project](https://github.com/tokio-rs/mini-redis), 
+For instance, to use tokio-console in [the mini-redis project](https://github.com/tokio-rs/mini-redis),
 you need to enable the `tracing` feature for the Tokio package:
 
 ```toml
@@ -29,7 +29,7 @@ console-subscriber = "0.1.5"
 ```
 
 Finally, in `src/bin/server.rs`, replace the call to `tracing_subscriber` with
-the call to `console-susbcriber`:
+the call to `console-subscriber`:
 
 Replace this:
 
@@ -122,7 +122,7 @@ To run an instance of Jaeger, you can use Docker:
 docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
 ```
 
-You can visit the Jaeger page by going to http://localhost:16686.
+You can visit the Jaeger page by going to <http://localhost:16686>.
 It will look like this:
 ![Jaeger UI](/img/tracing-next-steps/jaeger-first-pageload.png)
 

--- a/content/tokio/topics/tracing.md
+++ b/content/tokio/topics/tracing.md
@@ -22,6 +22,7 @@ messages.
 [`Event`]: https://docs.rs/tracing/latest/tracing/#events
 
 You can use `tracing` to:
+
 - emit distributed traces to an [OpenTelemetry] collector
 - debug your application with [Tokio Console]
 - log to [`stdout`], [a log file] or [`journald`]
@@ -88,7 +89,7 @@ If you run your application now, you may see some trace events emitted by Tokio,
 but you will need to modify your own application to emit traces to get the most
 out of `tracing`.
 
-##  Subscriber Configuration
+## Subscriber Configuration
 
 In the above example, we've configured [`FmtSubscriber`] with its default
 configuration. However, `tracing-subscriber` also provides a number of ways to
@@ -116,7 +117,6 @@ let subscriber = tracing_subscriber::fmt()
 
 For details on the available configuration options, see [the
 `tracing_subscriber::fmt` documentation][fmt-cfg].
-
 
 In addition to the [`FmtSubscriber`] type from [`tracing-subscriber`], other
 `Subscriber`s can implement their own ways of recording `tracing` data. This

--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -3,7 +3,7 @@ title: "Channels"
 ---
 
 Now that we have learned a bit about concurrency with Tokio, let's apply this on
-the client side. Put the server code we wrote before into an explicit binary 
+the client side. Put the server code we wrote before into an explicit binary
 file:
 
 ```text

--- a/content/tokio/tutorial/hello-tokio.md
+++ b/content/tokio/tutorial/hello-tokio.md
@@ -122,7 +122,7 @@ completes. Historically, this is a tedious and error-prone task.
 
 ## Compile-time green-threading
 
-Rust implements asynchronous programing using a feature called [`async/await`].
+Rust implements asynchronous programming using a feature called [`async/await`].
 Functions that perform asynchronous operations are labeled with the `async`
 keyword. In our example, the `connect` function is defined like this:
 
@@ -246,4 +246,3 @@ Tokio has a lot of functionality (TCP, UDP, Unix sockets, timers, sync
 utilities, multiple scheduler types, etc). Not all applications need all
 functionality. When attempting to optimize compile time or the end application
 footprint, the application can decide to opt into **only** the features it uses.
-

--- a/content/tokio/tutorial/select.md
+++ b/content/tokio/tutorial/select.md
@@ -67,7 +67,6 @@ Tokio's `oneshot::Receiver` implements `Drop` by sending a closed notification t
 the `Sender` half. The sender half can receive this notification and abort the
 in-progress operation by dropping it.
 
-
 ```rust
 use tokio::sync::oneshot;
 
@@ -278,7 +277,7 @@ computation.
 
 # Return value
 
-The `tokio::select!` macro returns the result of the evaluated `<handler>` expression. 
+The `tokio::select!` macro returns the result of the evaluated `<handler>` expression.
 
 ```rust
 async fn computation1() -> String {

--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -110,9 +110,8 @@ fine as long as contention remains low and the lock is not held across calls to
 
 The process function no longer initializes a `HashMap`. Instead, it takes the
 shared handle to the `HashMap` as an argument. It also needs to lock the
-`HashMap` before using it. Remember that the value's type for the HashMap 
-is now `Bytes` (which we can cheaply clone), so this needs to be changed
-as well.
+`HashMap` before using it. Remember that the value's type for the `HashMap` is
+now `Bytes` (which we can cheaply clone), so this needs to be changed as well.
 
 ```rust
 use tokio::net::TcpStream;

--- a/content/tokio/tutorial/streams.md
+++ b/content/tokio/tutorial/streams.md
@@ -406,8 +406,6 @@ stream! {
 [`Stream`]: https://docs.rs/futures-core/0.3/futures_core/stream/trait.Stream.html
 [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
 [`StreamExt`]: https://docs.rs/tokio-stream/0.1/tokio_stream/trait.StreamExt.html
-[rx]: https://docs.rs/tokio/1/tokio/sync/mpsc/struct.Receiver.html
-[`AsyncBufReadExt::lines()`]: https://docs.rs/tokio/1/tokio/io/trait.AsyncBufReadExt.html#method.lines
 [next]: https://docs.rs/tokio-stream/0.1/tokio_stream/trait.StreamExt.html#method.next
 [`map`]: https://docs.rs/tokio-stream/0.1/tokio_stream/trait.StreamExt.html#method.map
 [`take`]: https://docs.rs/tokio-stream/0.1/tokio_stream/trait.StreamExt.html#method.take


### PR DESCRIPTION
IMHO, the markdown in this repo should be formatted and relatively free of lints, because that lowers the barrier of entry for contributions. Let me know what you think :)