### PR TITLE
Docs: added missing word in spawning note

### DIFF
--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -184,7 +184,7 @@ outside the task.
 
 > **info**
 > It is a common misconception that `'static` always means "lives forever",
-> but this is not the case. Just because a value is `'static` does not mean
+> but this is not the case. Just because a value is `'static` it does not mean
 > that you have a memory leak. You can read more in [Common Rust Lifetime
 > Misconceptions][common-lifetime].
 


### PR DESCRIPTION
### Changes

- One word addition `is` added to note inside the spawning tutorial