### PR TITLE
Tutorial: Remove wildcard import of enum variants

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -221,13 +221,11 @@ let manager = tokio::spawn(async move {
 
     // Start receiving messages
     while let Some(cmd) = rx.recv().await {
-        use Command::*;
-
         match cmd {
-            Get { key } => {
+            Command::Get { key } => {
                 client.get(&key).await;
             }
-            Set { key, val } => {
+            Command::Set { key, val } => {
                 client.set(&key, val).await;
             }
         }


### PR DESCRIPTION
In the channels section of the tutorial, a use statement imports all variants of the Command enum,

```rust
    while let Some(cmd) = rx.recv().await {
        use Command::*;

        match cmd {
            Get { key } => {
                client.get(&key).await;
            }
            Set { key, val } => {
                client.set(&key, val).await;
            }
        }
    }
```

This is bad practice because renaming / removing something in the Command enum doesn't cause a compile time error, like in a normal match statement, and creates a catch-all in the match.

https://github.com/tokio-rs/website/assets/77034153/35d81fb7-9cfc-4941-bf38-cc544bebd93a

This PR just removes the `use Command::*` and changes the match statement to be on the full enum path in channels.md