### PR TITLE
fix: `# if true { return }` is not hidden in html code block

### DIFF
--- a/content/tokio/topics/testing.md
+++ b/content/tokio/topics/testing.md
@@ -166,7 +166,7 @@ be used as a mock:
 #         line.clear();
 #     }
 # }
-
+#
 #[tokio::test]
 async fn client_handler_replies_politely() {
     let reader = tokio_test::io::Builder::new()

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -18,7 +18,19 @@ const remarkCodeRemoveSomeLines = () => {
       if (node.lang && langs.includes(node.lang)) {
         node.value = node.value
           .split("\n")
-          .filter((line) => !line.startsWith("# "))
+          .map((line) => {
+            let trimmed = line.trim();
+            if (trimmed.startsWith("##")) {
+              return line.replace("##", "#");
+            } else if (trimmed.startsWith("# ")) {
+              return null;
+            } else if (trimmed === "#") {
+              return null;
+            } else {
+              return line;
+            }
+          })
+          .filter((line) => line !== null)
           .join("\n");
       }
     });


### PR DESCRIPTION
`# if true { return }` is shown in the code block of the topic page [Unit Testing](https://tokio.rs/tokio/topics/testing):

![](https://github.com/tokio-rs/website/assets/53310459/0d5a2f9a-4da1-4849-9293-dd554f0d8057)

Based on https://github.com/tokio-rs/website/pull/735, `# if true { return }` was used to let doc tests pass.
The original function to remove `#` lines does not cover all cases.
This PR fixes that function to match [what librustdoc does](https://github.com/rust-lang/rust/blob/0ecbd0605770f45c9151715e66ba2b3cae367fcb/src/librustdoc/html/markdown.rs#L170).

Another forgotten `#` on the same page:

![](https://github.com/tokio-rs/website/assets/53310459/f65daab2-c1f4-40ad-8e78-0774db1e34c1)

Also in blog [New Timer implementation](https://tokio.rs/blog/2018-03-timers):

![](https://github.com/tokio-rs/website/assets/53310459/d1a73b65-ef92-481d-9775-0cfc7e466d86)

These `#` lines will be removed by the fixed function.
