### PR TITLE
Delete old section of shared-state.md

### DIFF
--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -275,24 +275,6 @@ async fn increment_and_do_stuff(mutex: &Mutex<i32>) {
 }
 # async fn do_something_async() {}
 ```
-Note that this does not work:
-```rust
-use std::sync::{Mutex, MutexGuard};
-
-// This fails too.
-async fn increment_and_do_stuff(mutex: &Mutex<i32>) {
-    let mut lock: MutexGuard<i32> = mutex.lock().unwrap();
-    *lock += 1;
-    drop(lock);
-
-    do_something_async().await;
-}
-# async fn do_something_async() {}
-```
-This is because the compiler currently calculates whether a future is `Send`
-based on scope information only. The compiler will hopefully be updated to
-support explicitly dropping it in the future, but for now, you must explicitly
-use a scope.
 
 Note that the error discussed here is also discussed in the [Send bound section
 from the spawning chapter][send-bound].


### PR DESCRIPTION
The piece of code described now compiles as of Rust 1.76.0.

![image](https://github.com/tokio-rs/website/assets/16630834/f1b309f9-ca96-4354-8f2c-ef1080f1826f)
