### PR TITLE
Add missing `unwrap()`s

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -175,11 +175,13 @@ async fn main() {
     let tx2 = tx.clone();
 
     tokio::spawn(async move {
-        tx.send("sending from first handle").await;
+        // send() returns a `Result` which cannot be ignored.
+        tx.send("sending from first handle").await.unwrap();
     });
 
     tokio::spawn(async move {
-        tx2.send("sending from second handle").await;
+        // send() returns a `Result` which cannot be ignored.
+        tx2.send("sending from second handle").await.unwrap();
     });
 
     while let Some(message) = rx.recv().await {

--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -175,12 +175,10 @@ async fn main() {
     let tx2 = tx.clone();
 
     tokio::spawn(async move {
-        // send() returns a `Result` which cannot be ignored.
         tx.send("sending from first handle").await.unwrap();
     });
 
     tokio::spawn(async move {
-        // send() returns a `Result` which cannot be ignored.
         tx2.send("sending from second handle").await.unwrap();
     });
 


### PR DESCRIPTION
`tx.send()` returns a `Result` which must be used otherwise the compiler produces warnings.