### PR TITLE
fix: make redis integer frame signed

### DIFF
--- a/content/tokio/tutorial/framing.md
+++ b/content/tokio/tutorial/framing.md
@@ -13,7 +13,7 @@ use bytes::Bytes;
 enum Frame {
     Simple(String),
     Error(String),
-    Integer(u64),
+    Integer(i64),
     Bulk(Bytes),
     Null,
     Array(Vec<Frame>),


### PR DESCRIPTION
The documentation for the Frame enum in framing.md claims the Redis protocol frame for an integer is unsigned, which doesn't match the protocol spec: https://redis.io/docs/reference/protocol-spec/#integers

> This type is a CRLF-terminated string that represents a **signed**, base-10, 64-bit integer.

see also tokio-rs/mini-redis#128