### PR TITLE
Fixed watch

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -93,7 +93,7 @@ Tokio provides a [number of channels][channels], each serving a different purpos
 - [oneshot]: single-producer, single consumer channel. A single value can be sent.
 - [broadcast]: multi-producer, multi-consumer. Many values can be sent. Each
   receiver sees every value.
-- [watch]: single-producer, multi-consumer. Many values can be sent, but no
+- [watch]: multi-producer, multi-consumer. Many values can be sent, but no
   history is kept. Receivers only see the most recent value.
 
 If you need a multi-producer multi-consumer channel where only one consumer sees


### PR DESCRIPTION
`Clone` of `watch::Sender` was introduced in https://github.com/tokio-rs/tokio/pull/6388, and that change was shipped in the [latest v1.37.0 release](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.37.0).
So I fixed the document