### PR TITLE
Some edits for Tutorial: Shared State

### DIFF
--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -90,7 +90,7 @@ async fn main() {
 # async fn process(_: tokio::net::TcpStream, _: Db) {}
 ```
 
-## Most of the time, don't use `std::sync::Mutex`
+## On using `std::sync::Mutex` and `tokio::sync::Mutex`
 
 Note that `std::sync::Mutex` and **not** `tokio::sync::Mutex` is used to guard
 the `HashMap`. A common error is to unconditionally use `tokio::sync::Mutex`
@@ -275,8 +275,6 @@ mutex guard does not appear anywhere in an async function. It also protects you
 from deadlocks, when using crates whose `MutexGuard` implements `Send`.
 
 You can find a more detailed example [in this blog post][shared-mutable-state-blog-post].
-
-[shared-mutable-state-blog-post]: https://draft.ryhl.io/blog/shared-mutable-state/
 
 ## Spawn a task to manage the state and use message passing to operate on it
 

--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -331,7 +331,7 @@ never be contended.
 [basic-rt]: https://docs.rs/tokio/1/tokio/runtime/struct.Builder.html#method.new_current_thread
 
 If contention on a synchronous mutex becomes a problem, the best fix is rarely
-to switch to the Tokio mutex. Instead, options to consider are:
+to switch to the Tokio mutex. Instead, options to consider are to:
 
 - Let a dedicated task manage state and use message passing.
 - Shard the mutex.

--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -333,7 +333,7 @@ never be contended.
 If contention on a synchronous mutex becomes a problem, the best fix is rarely
 to switch to the Tokio mutex. Instead, options to consider are:
 
-- Switching to a dedicated task to manage state and use message passing.
+- Let a dedicated task manage state and use message passing.
 - Shard the mutex.
 - Restructure the code to avoid the mutex.
 


### PR DESCRIPTION
- Moved Tasks, threads and contention to the end:
  - This is deeper and more detailed than the previous sections
  - Also, the part on restructuring the code should be higher up
- Added more warnings on Send Guards.
- Linking to Alice Ryhl's post twice, both segments seem to benefit from this link.

This PR has some "quick fixes", that I believe would be helpful for tokio users at large.

The best thing we could do I believe, however, would be to sanitize the examples, so that all the example code would have wrapped mutexes only, making it much less likely for tokio users to end up with problematic code.