### PR TITLE
Corrected overflow-x style to remove unnecessary horizontal scroll bar

### DIFF
--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -934,7 +934,7 @@ Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine
 
 .hljs {
   display: block;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .hljs-comment,


### PR DESCRIPTION
Hi,

When I was browsing the website, I found unnecessary horizontal scroll bars under each of the code blocks, which kind of affect visual consistency, as the following image shows:

<img width="771" alt="x-bar" src="https://github.com/user-attachments/assets/3d4cb998-fc99-401d-aa41-d4f26f3156bd">

Then I went to the `styles.scss` file and found the attribute `overflow-x` was set to `scroll`. This means the horizontal scroll bar will always be there, whether the content is overflowing on the x-axis or not. I changed the value to `auto` to hide the bar when no overflow happens but show the scroll bar when horizontal scrolling is necessary. 
The result after this modification is as shown in the following images:

When no x-scrolling needed:
<img width="772" alt="no-x-bar" src="https://github.com/user-attachments/assets/4c3cb0a7-ba56-41b6-82e7-c8a1fcae581b">

When content overflows:
<img width="582" alt="Screenshot 2024-07-15 at 10 17 46 PM" src="https://github.com/user-attachments/assets/1b2b8156-24c9-4209-907e-e6b6dd71c1d5">

Thanks so much for considering this update!