### PR TITLE
Add styles to support printing the tutorial

### DIFF
--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -566,6 +566,50 @@ a:active {
   }
 }
 
+@media print {
+  // Hide these elements in the printed version
+  .footer,
+  .navbar,
+  .tk-announcement,
+  .tk-content-summary,
+  .tk-doc-footer,
+  .tk-docs-nav,
+  .tk-menu {
+    display: none !important;
+  }
+
+  // Remove excess whitespace and padding
+  .tk-content,
+  .tk-markdown {
+    padding: 0 !important;
+    // Override reduced width from column related styling
+    width: 100% !important;
+  }
+  .section {
+    padding: 0 !important;
+  }
+  // Restore missing margin
+  body,
+  .columns {
+    margin: revert !important;
+  }
+
+  pre {
+    // Wrap code blocks while printing, to avoid clipping content
+    white-space: pre-wrap !important;
+    overflow-wrap: break-word !important;
+    // Try to avoid breaking code blocks across separate pages, if possible.
+    break-inside: avoid !important;
+  }
+
+  // Force the stack images to look like they would before scrolling down. The
+  // implementation lives in components/stack.tsx, and the non-print styling is
+  // earlier in this file, near the other .anchor selector.
+  .tk-stack .anchor > img:not(#tk-stack-lines) {
+    opacity: 1 !important;
+  }
+}
+
 .tk-docs {
   .tk-docs-nav {
     background-color: $light-gray;


### PR DESCRIPTION
In particular, this makes it possible to save an offline copy of the tutorial to PDF or paper, or any blog posts of interest.