### PR TITLE
pin toolchain version to 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        run: rustup update stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.81 # because 1.82 broke tests with main functions in them
 
       - name: Build dependencies
         run: RUSTFLAGS="--cfg tokio_unstable" cargo build
@@ -50,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install node dependencies
         run: npm install

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+# rust 1.82 introduced a breaking change that causes the doc tests to fail
+channel = "1.81"


### PR DESCRIPTION
Fixes running doc-test locally
