### PR TITLE
use node.js 20.18.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install node dependencies
         run: npm install

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+node = "lts"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,0 @@
-[tools]
-node = "lts"

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
 [build.environment]
   # Environment variables are set here
 
-  NODE_VERSION = "18.13.0"
+  NODE_VERSION = "20.18.0"
 
   # For apps that use next export to generate static HTML
   # set the NETLIFY_NEXT_PLUGIN_SKIP to true.


### PR DESCRIPTION
This is the current LTS version which is recommended for prod usage.

Updates the netlify config and adds a mise.toml config file to configure
the node.js version to use when running the site locally.

This will fix the problem running next.js in https://github.com/tokio-rs/website/pull/778
