### PR TITLE
Add a missing apostrophe in "Inventing the Service Trait"

### DIFF
--- a/content/blog/2021-05-14-inventing-the-service-trait.md
+++ b/content/blog/2021-05-14-inventing-the-service-trait.md
@@ -264,7 +264,7 @@ Specifically `impl Fn() -> impl Future` is not allowed. Using `Box` would be
 possible but that has a performance cost we would like to avoid.
 
 You also wouldn't be able to add other behavior to your handlers besides calling
-them but why thats necessary is something we'll get back to.
+them but why that's necessary is something we'll get back to.
 
 # The `Handler` trait
 


### PR DESCRIPTION
Reading this great article, saw this missing apostrophe. I'm pretty sure it's supposed to read "...but why _that is_ necessary..." (emphasis added).

Thank you for all of the great work you folks do! Open source maintainers don't get enough :heart: 

- Nick