### PR TITLE
Mention futures create right before before it is needed

### DIFF
--- a/content/tokio/tutorial/async.md
+++ b/content/tokio/tutorial/async.md
@@ -207,6 +207,12 @@ outer future, driving the asynchronous computation to completion.
 To better understand how this all fits together, let's implement our own minimal
 version of Tokio! The full code can be found [here][mini-tokio].
 
+Add the following dependency to your `Cargo.toml` to pull in `futures`.
+
+```toml
+futures = "0.3"
+```
+
 ```rust
 use std::collections::VecDeque;
 use std::future::Future;
@@ -499,7 +505,7 @@ implementors, but requires a bunch of unsafe boilerplate code. Instead of using
 provided by the [`futures`] crate. This allows us to implement a simple trait to
 expose our `Task` struct as a waker.
 
-Add the following dependency to your `Cargo.toml` to pull in `futures`.
+If you haven't already, add the following dependency to your `Cargo.toml` to pull in `futures`.
 
 ```toml
 futures = "0.3"


### PR DESCRIPTION
I was just following the Tokio tutorial and notice that, in the Async in depth section, the `futures` crate is mentioned before there are instructions to add it to `Cargo.toml`.

First occurrence:
![image](https://github.com/user-attachments/assets/401858f0-c9ae-47fd-8c0f-dca680259a72)

But is only mentioned later in the tutorial:
![image](https://github.com/user-attachments/assets/9e79f06d-af85-4ed1-bc2a-dbbf163fc2b8)

This PR slightly changes the tutorial, so that the `cargo add` instructions are shown before the crate first usage.

Please let me know if further adjustments would be needed.
