### PR TITLE
Fix DynamoDB typo in Toasty blog post

### DIFF
--- a/content/blog/2024-10-23-announcing-toasty.md
+++ b/content/blog/2024-10-23-announcing-toasty.md
@@ -171,7 +171,7 @@ and fix it.
 # SQL and NoSQL
 
 Toasty supports both SQL and NoSQL databases. As of today, that means Sqlite and
-DyanmoDB, though adding support for other SQL databases should be pretty
+DynamoDB, though adding support for other SQL databases should be pretty
 straightforward. I also plan to add support for Cassandra soon, but I hope
 others will also contribute to implementations for different databases.
 


### PR DESCRIPTION
Noticed a minor typo while reading this article. Did the edit on phone and don't know how the `div` on line 208 differs and how that got into the diff.