### PR TITLE
Removed unnecessary -p argument to mkdir in tutorial.

### DIFF
--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -8,7 +8,7 @@ First, move the client `SET`/`GET` code from the previous section to an example
 file. This way, we can run it against our server.
 
 ```bash
-$ mkdir -p examples
+$ mkdir examples
 $ mv src/main.rs examples/hello-redis.rs
 ```
 


### PR DESCRIPTION
The -p option for mkdir creates parent directories. When run with a single identifier ( no / ) it would not effect the command, unless the working directory has been deleted, in which case the parameter would wrongly prevent an error. Removing increases clarity and simplicity of the tutorial.