### PR TITLE
Reformat long lines in tutorial examples.

### DIFF
--- a/content/tokio/topics/bridging.md
+++ b/content/tokio/topics/bridging.md
@@ -79,7 +79,10 @@ pub struct BlockingClient {
 }
 
 impl BlockingClient {
-    pub fn connect<T: ToSocketAddrs>(addr: T) -> crate::Result<BlockingClient> {
+    pub fn connect<T>(addr: T) -> crate::Result<BlockingClient>
+    where
+        T: ToSocketAddrs,
+    {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
@@ -135,7 +138,11 @@ impl BlockingClient {
         self.rt.block_on(self.inner.set_expires(key, value, expiration))
     }
 
-    pub fn publish(&mut self, channel: &str, message: Bytes) -> crate::Result<u64> {
+    pub fn publish(
+        &mut self,
+        channel: &str,
+        message: Bytes,
+    ) -> crate::Result<u64> {
         self.rt.block_on(self.inner.publish(channel, message))
     }
 }
@@ -160,7 +167,10 @@ pub struct BlockingSubscriber {
 }
 
 impl BlockingClient {
-    pub fn subscribe(self, channels: Vec<String>) -> crate::Result<BlockingSubscriber> {
+    pub fn subscribe(
+        self,
+        channels: Vec<String>,
+    ) -> crate::Result<BlockingSubscriber> {
         let subscriber = self.rt.block_on(self.inner.subscribe(channels))?;
         Ok(BlockingSubscriber {
             inner: subscriber,
@@ -178,11 +188,17 @@ impl BlockingSubscriber {
         self.rt.block_on(self.inner.next_message())
     }
 
-    pub fn subscribe(&mut self, channels: &[String]) -> crate::Result<()> {
+    pub fn subscribe(
+        &mut self,
+        channels: &[String],
+    ) -> crate::Result<()> {
         self.rt.block_on(self.inner.subscribe(channels))
     }
 
-    pub fn unsubscribe(&mut self, channels: &[String]) -> crate::Result<()> {
+    pub fn unsubscribe(
+        &mut self,
+        channels: &[String],
+    ) -> crate::Result<()> {
         self.rt.block_on(self.inner.unsubscribe(channels))
     }
 }

--- a/content/tokio/topics/shutdown.md
+++ b/content/tokio/topics/shutdown.md
@@ -55,8 +55,8 @@ async fn main() {
 
     // ... spawn application as separate task ...
     //
-    // application uses shutdown_send in case a shutdown was issued from inside
-    // the application
+    // application uses shutdown_send in case a shutdown was issued
+    // from inside the application
 
     tokio::select! {
         _ = signal::ctrl_c() => {},
@@ -113,7 +113,8 @@ let task1_handle = tokio::spawn(async move {
 tokio::spawn(async move {
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-    // Step 4: Cancel the original or cloned token to notify other tasks about shutting down gracefully
+    // Step 4: Cancel the original or cloned token to notify other
+    // tasks about shutting down gracefully
     token.cancel();
 });
 

--- a/content/tokio/topics/testing.md
+++ b/content/tokio/topics/testing.md
@@ -105,7 +105,9 @@ Consider now the actual client handler task, especially the `where`-clause of th
 function signature:
 
 ```rust
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::io::{
+    AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader,
+};
 
 async fn handle_connection<Reader, Writer>(
     reader: Reader,
@@ -124,7 +126,9 @@ where
                 break Ok(());
             }
             writer
-                .write_all(format!("Thanks for your message.\r\n").as_bytes())
+                .write_all(
+                    format!("Thanks for your message.\r\n").as_bytes()
+                )
                 .await
                 .unwrap();
         }

--- a/content/tokio/tutorial/io.md
+++ b/content/tokio/tutorial/io.md
@@ -88,7 +88,8 @@ use tokio::fs::File;
 async fn main() -> io::Result<()> {
     let mut file = File::create("foo.txt").await?;
 
-    // Writes some prefix of the byte string, but not necessarily all of it.
+    // Writes some prefix of the byte string, but not necessarily all
+    // of it.
     let n = file.write(b"some bytes").await?;
 
     println!("Wrote the first {} bytes of 'some bytes'.", n);
@@ -281,7 +282,7 @@ can use [`TcpStream::split`]. The task that processes the echo logic in the serv
 # fn dox(mut socket: TcpStream) {
 tokio::spawn(async move {
     let (mut rd, mut wr) = socket.split();
-    
+
     if io::copy(&mut rd, &mut wr).await.is_err() {
         eprintln!("failed to copy");
     }
@@ -316,20 +317,21 @@ async fn main() -> io::Result<()> {
 
             loop {
                 match socket.read(&mut buf).await {
-                    // Return value of `Ok(0)` signifies that the remote has
-                    // closed
+                    // Return value of `Ok(0)` signifies that the
+                    // remote has closed
                     Ok(0) => return,
                     Ok(n) => {
                         // Copy the data back to socket
                         if socket.write_all(&buf[..n]).await.is_err() {
-                            // Unexpected socket error. There isn't much we can
-                            // do here so just stop processing.
+                            // Unexpected socket error. There isn't
+                            // much we can do here, so just stop
+                            // processing.
                             return;
                         }
                     }
                     Err(_) => {
-                        // Unexpected socket error. There isn't much we can do
-                        // here so just stop processing.
+                        // Unexpected socket error. There isn't much
+                        // we can do here so just stop processing.
                         return;
                     }
                 }

--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -390,9 +390,10 @@ async fn process(socket: TcpStream) {
             }
             Get(cmd) => {
                 if let Some(value) = db.get(cmd.key()) {
-                    // `Frame::Bulk` expects data to be of type `Bytes`. This
-                    // type will be covered later in the tutorial. For now,
-                    // `&Vec<u8>` is converted to `Bytes` using `into()`.
+                    // `Frame::Bulk` expects data to be of type `Bytes`.
+                    // This type will be covered later in the
+                    // tutorial. For now, `&Vec<u8>` is converted to
+                    // `Bytes` using `into()`.
                     Frame::Bulk(value.clone().into())
                 } else {
                     Frame::Null


### PR DESCRIPTION
While most examples in the tutorial are carefully formatted to avoid the need for horizontal scroll bars, there are a few long lines. This PR reformats those long lines in examples to approximately 70-72 characters, which I believe brings them in line with the rest of the examples. I have tried to exercise sound judgement to maximize readability rather than applying the rule rigidly, and I have tried to maintain the original author's intent as carefully as possible. For instance, I have not tried to reword comments for brevity.

In my testing, all affected examples now render without horizontal scroll bars on a wide desktop layout.

All tests that passed previously still pass for me. (6 doc-tests failed for me before I made any changes, but that's a separate concern.)

## Example

Before:

![example (before)](https://github.com/user-attachments/assets/75b38320-749a-417f-9100-f5e412ab78b5)

After:

![example (after)](https://github.com/user-attachments/assets/c37577d8-6ecc-49b9-a071-4c84b0f15732)