### PR TITLE
Use Ok and Some variants in tokio::select! from shutdown example

### DIFF
--- a/content/tokio/topics/shutdown.md
+++ b/content/tokio/topics/shutdown.md
@@ -59,8 +59,8 @@ async fn main() {
     // the application
 
     tokio::select! {
-        _ = signal::ctrl_c() => {},
-        _ = shutdown_recv.recv() => {},
+        Ok(_) = signal::ctrl_c() => {},
+        Some(_) = shutdown_recv.recv() => {},
     }
 
     // send shutdown signal to application and wait


### PR DESCRIPTION

1. Use the `Ok` variant for `signal::ctrl_c()`
1. Use the `Some` variant for `shutdown_recv.recv()`

Adding these variants to the matcher should alleviate issues that a copy/paster might run into while running the examples.