### PR TITLE
refactor(mini-tokio): replace crossbeam with std channel

### DIFF
--- a/tutorial-code/mini-tokio/Cargo.toml
+++ b/tutorial-code/mini-tokio/Cargo.toml
@@ -9,4 +9,3 @@ publish = false
 
 [dependencies]
 futures = "0.3"
-crossbeam = "0.8"


### PR DESCRIPTION
Refactor code and comments to align with the changes in PR #727.