### PR TITLE
Minor: add a short explanation for "pipeline" in tutorial "Channel" chapter

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -66,7 +66,9 @@ means that exclusive access is required to call it. We could open a connection
 per task, but that is not ideal. We cannot use `std::sync::Mutex` as `.await`
 would need to be called with the lock held. We could use `tokio::sync::Mutex`,
 but that would only allow a single in-flight request. If the client implements
-[pipelining], an async mutex results in underutilizing the connection.
+[pipelining](in short, sending many commands without waiting for each prior
+command's response), an async mutex results in underutilizing
+the connection.
 
 [pipelining]: https://redis.io/topics/pipelining
 


### PR DESCRIPTION
When I read the chapter *Channel*, I feel like beginners can be already overwhelmed by suddenly encountering so many new terms to some extent, and since the concept of *pipelining* comes from Redis, readers who aren’t familiar with Redis may find it even more confusing. That being said even if we provide a link to explain everything about *pipeline*, it’s necessary to include a brief explanation of pipelining directly in the article. So, a brief parenthetical explanation has been inserted immediately after the word *pipeline*.
