### PR TITLE
Use UTC functions on date objects

### DIFF
--- a/components/menu.tsx
+++ b/components/menu.tsx
@@ -83,7 +83,7 @@ function Level1({ href, menu }) {
       link = (
         <a href={entry.href}>
           <b>
-            {monthNames[date.getMonth()]} {date.getDate()}
+            {monthNames[date.getUTCMonth()]} {date.getUTCDate()}
           </b>
           {entry.title}
         </a>

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -16,7 +16,7 @@ export function getBlogPostsByYear(limit?: number) {
       return years;
     }
     const date = new Date(post.date);
-    const year = date.getFullYear().toString();
+    const year = date.getUTCFullYear().toString();
     if (!years[year]) {
       years[year] = {
         key: year,


### PR DESCRIPTION
Currently, the sidebar on blog pages shows the wrong date for the posts – they are all off by one.

The markdown files have pages with no specified timezone, so `new Date(post.date)` parses these in UTC. However, the `getDate/Month/Year` functions use the local timezone. This makes the dates that show up on the sidebar dependent on the current time of the build machine.

Fixed:

<img width="317" alt="image" src="https://github.com/user-attachments/assets/78f6ad6e-c694-4855-be9a-37177345adfb" />


Previously: 

<img width="317" alt="image" src="https://github.com/user-attachments/assets/dc7a1036-eadd-4460-811f-01be906ee6f4" />

