### PR TITLE
Disambiguate client-server references in Spawning tutorial

### DIFF
--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -69,7 +69,8 @@ $ cargo run
 ```
 
 In a separate terminal window, run the `hello-redis` example (the `SET`/`GET`
-command from the previous section):
+command from the previous section, which is playing the role of the Redis
+client):
 
 ```bash
 $ cargo run --example hello-redis
@@ -413,13 +414,13 @@ Now, start the server:
 $ cargo run
 ```
 
-and in a separate terminal window, run the `hello-redis` example:
+and in a separate terminal window, run the `hello-redis` client example again:
 
 ```bash
 $ cargo run --example hello-redis
 ```
 
-Now, the output will be:
+Now, the output from the client will be:
 
 ```text
 got value from the server; result=Some(b"world")


### PR DESCRIPTION
Based on https://github.com/tokio-rs/tokio/issues/7423, the spawning tutorial has the user running both the Redis server and client in separate terminal windows. Let's disambiguate which terminal window the user should be expecting output from.

Fixes: https://github.com/tokio-rs/tokio/issues/7423