### PR TITLE
Show expected client/server terminal output at the end of channels tutorial

### DIFF
--- a/content/tokio/tutorial/channels.md
+++ b/content/tokio/tutorial/channels.md
@@ -425,6 +425,41 @@ dropped. This indicates the receiver is no longer interested in the response. In
 our scenario, the receiver cancelling interest is an acceptable event. The `Err`
 returned by `resp.send(...)` does not need to be handled.
 
+Now, when running the server in one terminal:
+```bash
+$ cargo run --bin server
+```
+
+You should see the following output:
+```text
+Listening
+```
+
+Then, after running the client in a __separate__ terminal:
+```bash
+$ cargo run --bin client
+```
+
+The server terminal should show this output:
+```text
+Listening
+Accepted
+```
+
+And the client terminal should show either this output:
+```text
+GOT = Ok(Ok(()))
+GOT = Ok(Ok(Some(b"bar")))
+```
+
+Or this output:
+```text
+GOT = Ok(Ok(Some(b"bar")))
+GOT = Ok(Ok(()))
+```
+
+Depending on which task was processed first by the scheduler.
+
 You can find the entire code [here][full].
 
 # Backpressure and bounded channels


### PR DESCRIPTION
I really like the approach of documenting the expected terminal output of code-snippets in the tutorial, as this lets the reader sanity-check their own code, which also helps with engagement by encouraging them to run the tutorial code themselves.

Here's an example of this from the `spawning` section:
https://github.com/tokio-rs/website/blob/ec56f48d46d407cab1c22439edf8d80caee31a61/content/tokio/tutorial/spawning.md?plain=1#L65-L88

This PR follows that same pattern but for the `channels` section, which at the time of writing does not show the expected client/server terminal outputs at the end of the section.

`doc-test` is passing following these changes:
<img width="1163" height="147" alt="image" src="https://github.com/user-attachments/assets/45a4256c-1246-4b43-a9a0-8c6513b4d30b" />