### PR TITLE
clarify paragraph in "On using `std::sync::Mutex` and `tokio::sync::Mutex`

### DIFF
--- a/content/tokio/tutorial/shared-state.md
+++ b/content/tokio/tutorial/shared-state.md
@@ -98,9 +98,10 @@ from within async code. An async mutex is a mutex that is locked across calls
 to `.await`.
 
 A synchronous mutex will block the current thread when waiting to acquire the
-lock. This, in turn, will block other tasks from processing. However, switching
-to `tokio::sync::Mutex` usually does not help as the asynchronous mutex uses a
-synchronous mutex internally.
+lock. This, in turn, will block other tasks from processing. Switching
+to `tokio::sync::Mutex` will cause the task to yield control back to the
+executor, but this will usually not help with performance as the asynchronous
+mutex uses a synchronous mutex internally.
 
 As a rule of thumb, using a synchronous mutex from within asynchronous code is
 fine as long as contention remains low and the lock is not held across calls to


### PR DESCRIPTION
The way that this paragraph is written right now it makes it seem that `tokio::sync::Mutex::lock` will block the executor even if the function is `async`.

As [clarified here](https://users.rust-lang.org/t/which-mutex-should-i-use-for-single-thread-tokio-tasks/70584/5), this is not the case and the intention of the paragraph is to mention, instead, that this kind of mutex isn't more performant.

Personally, this paragraph has confused me on this behavior in the past. I'm not sure if the wording I used is the best to capture the original intention but I'd like if it can be updated.

Thanks!