### PR TITLE
Upgrade dial9-tokio-telemetry to version 0.2

### DIFF
--- a/content/blog/2026-03-18-dial9.md
+++ b/content/blog/2026-03-18-dial9.md
@@ -72,7 +72,7 @@ Add the dependency: `cargo add dial9-tokio-telemetry`:
 
 ```toml
 [dependencies]
-dial9-tokio-telemetry = "0.1"
+dial9-tokio-telemetry = "0.2"
 ```
 
 Wrap your runtime with `TracedRuntime`:


### PR DESCRIPTION
bump version so that folks reading the blog post to add the dep get the newest version