### PR TITLE
remove harmless unnecessary move in redis example

### DIFF
--- a/content/tokio/tutorial/spawning.md
+++ b/content/tokio/tutorial/spawning.md
@@ -128,7 +128,7 @@ async fn main() {
         let (socket, _) = listener.accept().await.unwrap();
         // A new task is spawned for each inbound socket. The socket is
         // moved to the new task and processed there.
-        tokio::spawn(async move {
+        tokio::spawn(async {
             process(socket).await;
         });
     }


### PR DESCRIPTION
it's unnecessary because process takes socket by value, so compiler already knows to move it.

including move keyword here may confuse and distract the reader, as it did me